### PR TITLE
fix(gateway): Delegate VaultService authentication to the downstream …

### DIFF
--- a/src/gateways/SecureVault.ApiGateway/ocelot.json
+++ b/src/gateways/SecureVault.ApiGateway/ocelot.json
@@ -12,11 +12,7 @@
       "UpstreamHttpMethod": [ "GET", "POST", "PUT", "DELETE" ],
       "DownstreamPathTemplate": "/{everything}",
       "DownstreamScheme": "http",
-      "ServiceName": "VaultService",
-      "AuthenticationOptions": {
-        "AuthenticationProviderKey": "Bearer",
-        "AllowedScopes": []
-      }
+      "ServiceName": "VaultService"
     }
   ],
   "GlobalConfiguration": {


### PR DESCRIPTION
## 📝 Problem
The Ocelot API Gateway was configured to handle authentication for the `/vault` route via its `AuthenticationOptions`. When a client sent an expired or invalid token, Ocelot would intercept the request and return its own error, which was not a standard `401 Unauthorized`.

This behavior prevented our client-side refresh token mechanism from triggering, as it is designed to activate upon receiving a `401` status code.

## 🛠️ Solution
This PR removes the `AuthenticationOptions` block from the `/vault` route definition in `ocelot.json`. By doing this, we delegate the responsibility of token validation entirely to the downstream `VaultService`.

Now, the `VaultService` itself validates the token. If the token is invalid, the service correctly returns a `401 Unauthorized` status code, which Ocelot passes through to the client.

## ✅ Impact
With the client now receiving the proper `401` response, the refresh token flow works as intended, allowing for seamless session management and keeping the user logged in without interruption.