### PR TITLE
refactor(ui): Move QrCodeScannerPage to a shared helpers directory

### DIFF
--- a/src/clients/SecureVault.App/Components/Helpers/QrScannerPage.xaml
+++ b/src/clients/SecureVault.App/Components/Helpers/QrScannerPage.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:zxing="clr-namespace:ZXing.Net.Maui.Controls;assembly=ZXing.Net.Maui.Controls"
              xmlns:zxingcore="clr-namespace:ZXing.Net.Maui;assembly=ZXing.Net.Maui"
-             x:Class="SecureVault.App.Components.Pages.VaultItem.Helpers.QrScannerPage"
+             x:Class="SecureVault.App.Components.Helpers.QrScannerPage"
              Title="QR Kod Okuyucu">
     <Grid>
         <zxing:CameraBarcodeReaderView

--- a/src/clients/SecureVault.App/Components/Helpers/QrScannerPage.xaml.cs
+++ b/src/clients/SecureVault.App/Components/Helpers/QrScannerPage.xaml.cs
@@ -1,6 +1,6 @@
 using ZXing.Net.Maui;
 
-namespace SecureVault.App.Components.Pages.VaultItem.Helpers;
+namespace SecureVault.App.Components.Helpers;
 
 public partial class QrScannerPage : ContentPage
 {


### PR DESCRIPTION
## 📝 Description
This Pull Request refactors the project structure for better reusability.

### Why this change is needed
The `QrCodeScannerPage` component was initially located within a feature-specific directory (`Components/Pages/VaultItems/Helpers`). However, its functionality is generic and will be reused in other parts of the application. Keeping it in a feature-specific folder would lead to code duplication or improper dependencies in the future.

### Solution
This refactor moves the `QrCodeScannerPage` and its associated code-behind file to a shared, top-level helpers directory (`Components/Helpers`), establishing it as a reusable component for the entire application.

### Impact
This improves the project's architecture, promotes code reuse, and makes the component easily accessible for any future features that may require QR code scanning. This is a non-breaking structural change.