### PR TITLE
feat(client): Implement Polly for resilient API communication

### DIFF
--- a/src/clients/SecureVault.App.Application.Contracts/Abstractions/Api/IInteractionService.cs
+++ b/src/clients/SecureVault.App.Application.Contracts/Abstractions/Api/IInteractionService.cs
@@ -1,7 +1,9 @@
-﻿namespace SecureVault.App.Application.Contracts.Abstractions.Api
+﻿using SecureVault.Shared.Result;
+
+namespace SecureVault.App.Application.Contracts.Abstractions.Api
 {
     public interface IInteractionService
     {
-        Task<string> CreateQrLoginChannelAsync(CancellationToken cancellationToken);
+        Task<Result<string>> CreateQrLoginChannelAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/clients/SecureVault.App.Infrastructure/HttpHandlers/AddBearerTokenHandler.cs
+++ b/src/clients/SecureVault.App.Infrastructure/HttpHandlers/AddBearerTokenHandler.cs
@@ -1,4 +1,5 @@
-﻿using SecureVault.App.Application.Contracts.Abstractions.Persistence;
+﻿using Microsoft.Extensions.Logging;
+using SecureVault.App.Application.Contracts.Abstractions.Persistence;
 using System.Net.Http.Headers;
 
 namespace SecureVault.App.Infrastructure.HttpHandlers
@@ -6,26 +7,32 @@ namespace SecureVault.App.Infrastructure.HttpHandlers
     internal class AddBearerTokenHandler : DelegatingHandler
     {
         private readonly IStorageService _storageService;
-
-        public AddBearerTokenHandler(IStorageService storageService)
+        private readonly ILogger<AddBearerTokenHandler> _logger;
+        public AddBearerTokenHandler(IStorageService storageService, ILogger<AddBearerTokenHandler> logger)
         {
             _storageService = storageService;
+            _logger = logger;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            if (request.Headers.TryGetValues("X-Anonymous", out _))
+            try
             {
-                request.Headers.Remove("X-Anonymous");
+                if (request.Headers.Remove("X-Anonymous"))
+                {
+                    var bearer = await _storageService.GetAccessTokenAsync();
 
-                var bearer = await _storageService.GetAccessTokenAsync();
-
-                if (!string.IsNullOrEmpty(bearer))
-                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+                    if (!string.IsNullOrEmpty(bearer))
+                        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+                }
 
                 return await base.SendAsync(request, cancellationToken);
             }
-            return await base.SendAsync(request, cancellationToken);
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "AddBearerTokenHandler içerisinde bir hata oluştu. İstek URI: {RequestUri}", request.RequestUri);
+                throw;
+            }
         }
     }
 }

--- a/src/clients/SecureVault.App.Infrastructure/HttpHandlers/HttpHandlerPipelineBuilder.cs
+++ b/src/clients/SecureVault.App.Infrastructure/HttpHandlers/HttpHandlerPipelineBuilder.cs
@@ -32,13 +32,15 @@ namespace SecureVault.App.Infrastructure.HttpHandlers
                 }
             };
 
+            var pollyResiliencyHandler = _serviceProvider.GetRequiredService<PollyResiliencyHandler>();
             var deviceHeadersHandler = _serviceProvider.GetRequiredService<DeviceHeadersHandler>();
             var authTokenHandler = _serviceProvider.GetRequiredService<AuthTokenHandler>();
 
+            pollyResiliencyHandler.InnerHandler = deviceHeadersHandler;
             deviceHeadersHandler.InnerHandler = authTokenHandler;
             authTokenHandler.InnerHandler = customFinalHandler;
 
-            return deviceHeadersHandler;
+            return pollyResiliencyHandler;
         }
     }
 }

--- a/src/clients/SecureVault.App.Infrastructure/HttpHandlers/PollyResiliencyHandler.cs
+++ b/src/clients/SecureVault.App.Infrastructure/HttpHandlers/PollyResiliencyHandler.cs
@@ -1,0 +1,51 @@
+﻿using Polly;
+using Polly.Extensions.Http;
+using Polly.Wrap;
+using System.Net;
+
+namespace SecureVault.App.Infrastructure.HttpHandlers
+{
+    public class PollyResiliencyHandler : DelegatingHandler
+    {
+        private static readonly AsyncPolicyWrap<HttpResponseMessage> _resiliencyPolicy = CreateResiliencyPolicy();
+
+        private static AsyncPolicyWrap<HttpResponseMessage> CreateResiliencyPolicy()
+        {
+            var retryPolicy = HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .OrResult(msg => msg.StatusCode == HttpStatusCode.TooManyRequests)
+                .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
+                    onRetry: (outcome, timespan, retryAttempt, context) =>
+                    {
+                        Console.WriteLine($"[Polly-Retry] İstek başarısız oldu: {outcome.Result?.StatusCode}. " +
+                                          $"Deneme {retryAttempt}. {timespan.TotalSeconds} saniye sonra yeniden denenecek...");
+                    });
+
+            var circuitBreakerPolicy = HttpPolicyExtensions
+                .HandleTransientHttpError()
+                .CircuitBreakerAsync(
+                    handledEventsAllowedBeforeBreaking: 5,
+                    durationOfBreak: TimeSpan.FromSeconds(30),
+                    onBreak: (result, timespan, context) =>
+                    {
+                        Console.WriteLine($"[Polly-Breaker] Devre açıldı! Süre: {timespan.TotalSeconds} saniye.");
+                    },
+                    onReset: (context) =>
+                    {
+                        Console.WriteLine("[Polly-Breaker] Devre kapatıldı. İstekler yeniden gönderilecek.");
+                    },
+                    onHalfOpen: () =>
+                    {
+                        Console.WriteLine("[Polly-Breaker] Devre yarı-açık. Bir sonraki istek deneme amaçlı gönderilecek.");
+                    }
+                );
+
+            return Policy.WrapAsync(circuitBreakerPolicy, retryPolicy);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return _resiliencyPolicy.ExecuteAsync(() => base.SendAsync(request, cancellationToken));
+        }
+    }
+}

--- a/src/clients/SecureVault.App.Infrastructure/InfrastructureServiceRegistration.cs
+++ b/src/clients/SecureVault.App.Infrastructure/InfrastructureServiceRegistration.cs
@@ -44,6 +44,7 @@ namespace SecureVault.App.Infrastructure
             services.AddTransient<DeviceHeadersHandler>();
             services.AddTransient<AuthTokenHandler>();
             services.AddTransient<AddBearerTokenHandler>();
+            services.AddTransient<PollyResiliencyHandler>();
             services.AddSingleton<IHttpHandlerPipelineBuilder, HttpHandlerPipelineBuilder>();   
 
             //repositories
@@ -115,12 +116,14 @@ namespace SecureVault.App.Infrastructure
             }
             services.AddRefitClient<ISecureVaultAuthorizeApi>(refitSettings)
                     .ConfigureHttpClient(configureClient)
+                    .AddHttpMessageHandler<PollyResiliencyHandler>()
                     .AddHttpMessageHandler<DeviceHeadersHandler>()
                     .AddHttpMessageHandler<AuthTokenHandler>()
                     .ConfigurePrimaryHttpMessageHandler(() => configureHandler(apiSettings.DevMachineName));
 
             services.AddRefitClient<ISecureVaultAnonymousApi>(refitSettings)
                     .ConfigureHttpClient(configureClient)
+                    .AddHttpMessageHandler<PollyResiliencyHandler>()
                     .AddHttpMessageHandler<DeviceHeadersHandler>()
                     .AddHttpMessageHandler<AddBearerTokenHandler>()
                     .ConfigurePrimaryHttpMessageHandler(() => configureHandler(apiSettings.DevMachineName));

--- a/src/clients/SecureVault.App.Infrastructure/SecureVault.App.Infrastructure.csproj
+++ b/src/clients/SecureVault.App.Infrastructure/SecureVault.App.Infrastructure.csproj
@@ -17,6 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.9" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.100" />
+    <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     <PackageReference Include="Refit" Version="8.0.0" />
     <PackageReference Include="Refit.HttpClientFactory" Version="8.0.0" />
   </ItemGroup>

--- a/src/clients/SecureVault.App.Infrastructure/Services/Api/AuthService.cs
+++ b/src/clients/SecureVault.App.Infrastructure/Services/Api/AuthService.cs
@@ -1,4 +1,5 @@
-﻿using Refit;
+﻿using Polly.CircuitBreaker;
+using Refit;
 using SecureVault.App.Application.Contracts.Abstractions.Api;
 using SecureVault.App.Application.Contracts.Abstractions.Cryptography;
 using SecureVault.App.Application.Contracts.Abstractions.Persistence;
@@ -18,10 +19,10 @@ namespace SecureVault.App.Infrastructure.Services.Api
         private readonly ISecureVaultAnonymousApi _secureVaultAnonymousApi;
         private readonly IStorageService _storageService;
         public AuthService(IHashService hashService,
-                           IAuthenticationStateNotifier authenticationStateNotifier,
-                           IBouncyCastleCryptoService bouncyCastleCryptoService,
-                           ISecureVaultAnonymousApi secureVaultAnonymousApi,
-                           IStorageService storageService)
+                               IAuthenticationStateNotifier authenticationStateNotifier,
+                               IBouncyCastleCryptoService bouncyCastleCryptoService,
+                               ISecureVaultAnonymousApi secureVaultAnonymousApi,
+                               IStorageService storageService)
         {
             _hashService = hashService;
             _authenticationStateNotifier = authenticationStateNotifier;
@@ -34,27 +35,34 @@ namespace SecureVault.App.Infrastructure.Services.Api
             try
             {
                 var challengeDto = await _secureVaultAnonymousApi.GetChallengeAsync(loginDto.Email, cancellationToken);
-
                 var masterSecret = _hashService.CreateMasterSecret(loginDto.Password, challengeDto.Salt);
                 byte[] privateKey = _hashService.GetPrivateKeyForAuth(masterSecret, challengeDto.Salt);
-
                 var signatureHex = SignChallenge(challengeDto.Challenge, privateKey);
-
                 var loginCredentials = new LoginCredentialsDto(loginDto.Email, signatureHex);
                 var authResponse = await _secureVaultAnonymousApi.LoginAsync(loginDto.RememberMe, loginCredentials, cancellationToken);
-
                 await _storageService.SetTokensAsync(authResponse);
                 byte[] encryptionKey = _hashService.GetEncryptionKeyForData(masterSecret, challengeDto.Salt);
                 await _storageService.SetKeysAsync(privateKey, encryptionKey);
                 _storageService.SetEmail(loginDto.Email);
                 await _authenticationStateNotifier.NotifyUserAuthenticated(authResponse.AccessToken);
-
                 return Result.Success();
+            }
+            catch (BrokenCircuitException)
+            {
+                return Result.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor. Lütfen birkaç dakika sonra tekrar deneyin."));
             }
             catch (ApiException ex)
             {
                 var error = await ex.GetContentAsAsync<Error>();
-                return Result.Failure(error ?? new Error("Client.NetworkError", "Bir hata oluştu."));
+                return Result.Failure(error ?? new Error("Client.LoginFailed", "Giriş başarısız."));
+            }
+            catch (HttpRequestException)
+            {
+                return Result.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı. Lütfen internet bağlantınızı kontrol edin veya daha sonra tekrar deneyin."));
+            }
+            catch (Exception)
+            {
+                return Result.Failure(new Error("Client.UnexpectedError", "Beklenmedik bir hata oluştu. Lütfen daha sonra tekrar deneyin."));
             }
         }
 
@@ -63,23 +71,31 @@ namespace SecureVault.App.Infrastructure.Services.Api
             try
             {
                 var challengeDto = await _secureVaultAnonymousApi.GetChallengeAsync(loginQrCodeDto.Email, cancellationToken);
-
                 var signatureHex = SignChallenge(challengeDto.Challenge, loginQrCodeDto.PrivateKey);
-
                 var loginCredentials = new LoginCredentialsDto(loginQrCodeDto.Email, signatureHex);
                 var authResponse = await _secureVaultAnonymousApi.LoginAsync(true, loginCredentials, cancellationToken);
-
                 await _storageService.SetTokensAsync(authResponse);
                 await _storageService.SetKeysAsync(loginQrCodeDto.PrivateKey, loginQrCodeDto.EncryptionKey);
                 _storageService.SetEmail(loginQrCodeDto.Email);
                 await _authenticationStateNotifier.NotifyUserAuthenticated(authResponse.AccessToken);
-
                 return Result.Success();
+            }
+            catch (BrokenCircuitException)
+            {
+                return Result.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor. Lütfen birkaç dakika sonra tekrar deneyin."));
             }
             catch (ApiException ex)
             {
                 var error = await ex.GetContentAsAsync<Error>();
-                return Result.Failure(error ?? new Error("Client.NetworkError", "Bir hata oluştu."));
+                return Result.Failure(error ?? new Error("Client.LoginFailed", "Giriş başarısız."));
+            }
+            catch (HttpRequestException)
+            {
+                return Result.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı. Lütfen internet bağlantınızı kontrol edin veya daha sonra tekrar deneyin."));
+            }
+            catch (Exception)
+            {
+                return Result.Failure(new Error("Client.UnexpectedError", "Beklenmedik bir hata oluştu. Lütfen daha sonra tekrar deneyin."));
             }
         }
         public async Task<Result?> RefreshTokenAsync(CancellationToken cancellationToken)
@@ -99,11 +115,23 @@ namespace SecureVault.App.Infrastructure.Services.Api
                 await _storageService.SetTokensAsync(authResponse);
                 return Result.Success();
             }
+            catch (BrokenCircuitException)
+            {
+                return Result.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor. Lütfen birkaç dakika sonra tekrar deneyin."));
+            }
             catch (ApiException ex)
             {
                 await LogoutAsync(cancellationToken);
                 var error = await ex.GetContentAsAsync<Error>();
                 return Result.Failure(error ?? new Error("Auth.InvalidRefreshToken", "Token yenileme başarısız."));
+            }
+            catch (HttpRequestException)
+            {
+                return Result.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı. Token yenilenemedi."));
+            }
+            catch (Exception)
+            {
+                return Result.Failure(new Error("Client.UnexpectedError", "Token yenileme sırasında beklenmedik bir hata oluştu."));
             }
         }
 
@@ -118,12 +146,15 @@ namespace SecureVault.App.Infrastructure.Services.Api
                 {
                     await _secureVaultAnonymousApi.LogoutAsync(refreshToken, cancellationToken);
                 }
-                catch (ApiException)
+                catch (Exception)
                 {
+                    // Logout sırasında sunucuya ulaşılamasa bile sorun değil.
+                    // Akışın devam edip local token'ları temizlemesi daha önemli.
+                    // Bu yüzden bu blokta hatayı yutuyoruz.
                 }
             }
 
-            await _authenticationStateNotifier.NotifyUserLogout(); 
+            await _authenticationStateNotifier.NotifyUserLogout();
             return Result.Success();
         }
 

--- a/src/clients/SecureVault.App.Infrastructure/Services/Api/InteractionService.cs
+++ b/src/clients/SecureVault.App.Infrastructure/Services/Api/InteractionService.cs
@@ -1,20 +1,57 @@
-﻿using SecureVault.App.Application.Contracts.Abstractions.Api;
+﻿using Microsoft.Extensions.Logging;
+using Polly.CircuitBreaker;
+using Refit;
+using SecureVault.App.Application.Contracts.Abstractions.Api;
+using SecureVault.Shared.Result;
 
 namespace SecureVault.App.Infrastructure.Services.Api
 {
     public class InteractionService : IInteractionService
     {
         private readonly ISecureVaultAnonymousApi _secureVaultAnonymousApi;
+        private readonly ILogger<InteractionService> _logger;
 
-        public InteractionService(ISecureVaultAnonymousApi secureVaultAnonymousApi)
+        public InteractionService(ISecureVaultAnonymousApi secureVaultAnonymousApi, ILogger<InteractionService> logger)
         {
             _secureVaultAnonymousApi = secureVaultAnonymousApi;
+            _logger = logger;
         }
 
-        public async Task<string> CreateQrLoginChannelAsync(CancellationToken cancellationToken)
+        public async Task<Result<string>> CreateQrLoginChannelAsync(CancellationToken cancellationToken)
         {
-            var response = await _secureVaultAnonymousApi.CreateChannelAsync(cancellationToken);
-            return response.ChannelId;
+            try
+            {
+                var response = await _secureVaultAnonymousApi.CreateChannelAsync(cancellationToken);
+
+                if (string.IsNullOrEmpty(response?.ChannelId))
+                {
+                    _logger.LogWarning("CreateChannelAsync başarılı bir yanıt döndü ancak ChannelId boş.");
+                    return Result<string>.Failure(new Error("Api.EmptyResponse", "API'den geçerli bir kanal kimliği alınamadı."));
+                }
+
+                return Result<string>.Success(response.ChannelId);
+            }
+            catch (BrokenCircuitException)
+            {
+                _logger.LogError("Devre açık. QR giriş kanalı oluşturulamadı.");
+                return Result<string>.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor. Lütfen birkaç dakika sonra tekrar deneyin."));
+            }
+            catch (ApiException ex)
+            {
+                _logger.LogError(ex, "QR giriş kanalı oluşturulurken API hatası. Durum Kodu: {StatusCode}", ex.StatusCode);
+                var error = await ex.GetContentAsAsync<Error>();
+                return Result<string>.Failure(error ?? new Error("Api.RequestFailed", "Kanal oluşturma isteği başarısız oldu."));
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "QR giriş kanalı oluşturulurken ağ hatası.");
+                return Result<string>.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı. Lütfen internet bağlantınızı kontrol edin veya daha sonra tekrar deneyin."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "QR giriş kanalı oluşturulurken beklenmedik bir hata oluştu.");
+                return Result<string>.Failure(new Error("Client.UnexpectedError", "Beklenmedik bir hata oluştu. Lütfen daha sonra tekrar deneyin."));
+            }
         }
     }
 }

--- a/src/clients/SecureVault.App.Infrastructure/Services/Api/RegisterService.cs
+++ b/src/clients/SecureVault.App.Infrastructure/Services/Api/RegisterService.cs
@@ -1,4 +1,6 @@
-﻿using Refit;
+﻿using Microsoft.Extensions.Logging;
+using Polly.CircuitBreaker;
+using Refit;
 using SecureVault.App.Application.Contracts.Abstractions.Api;
 using SecureVault.App.Application.Contracts.DTOs.Register;
 using SecureVault.Shared.Result;
@@ -8,10 +10,12 @@ namespace SecureVault.App.Infrastructure.Services.Api
     public class RegisterService : IRegisterService
     {
         private readonly ISecureVaultAnonymousApi _secureVaultAnonymousApi;
+        private readonly ILogger<RegisterService> _logger;
 
-        public RegisterService(ISecureVaultAnonymousApi secureVaultAnonymousApi)
+        public RegisterService(ISecureVaultAnonymousApi secureVaultAnonymousApi, ILogger<RegisterService> logger)
         {
             _secureVaultAnonymousApi = secureVaultAnonymousApi;
+            _logger = logger;
         }
 
         public async Task<Result?> RegisterAsync(RegisterUserDto registerUserDto, CancellationToken cancellationToken)
@@ -25,10 +29,26 @@ namespace SecureVault.App.Infrastructure.Services.Api
                 var error = await response.Error.GetContentAsAsync<Error>();
                 return Result.Failure(error ?? new Error("Client.RegisterFailed", "Kayıt başarısız."));
             }
+            catch (BrokenCircuitException)
+            {
+                _logger.LogError("Devre açık. Kayıt işlemi yapılamadı.");
+                return Result.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor. Lütfen birkaç dakika sonra tekrar deneyin."));
+            }
             catch (ApiException ex)
             {
+                _logger.LogError(ex, "Kayıt işlemi sırasında API hatası. Durum Kodu: {StatusCode}", ex.StatusCode);
                 var error = await ex.GetContentAsAsync<Error>();
-                return Result.Failure(error ?? new Error("Client.NetworkError", "Bir hata oluştu."));
+                return Result.Failure(error ?? new Error("Api.RequestFailed", "Kayıt olma isteği başarısız oldu."));
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Kayıt işlemi sırasında ağ hatası.");
+                return Result.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı. Lütfen internet bağlantınızı kontrol edin veya daha sonra tekrar deneyin."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Kayıt işlemi sırasında beklenmedik bir hata oluştu.");
+                return Result.Failure(new Error("Client.UnexpectedError", "Beklenmedik bir hata oluştu. Lütfen daha sonra tekrar deneyin."));
             }
         }
     }

--- a/src/clients/SecureVault.App.Infrastructure/Services/Api/UserSessionService.cs
+++ b/src/clients/SecureVault.App.Infrastructure/Services/Api/UserSessionService.cs
@@ -1,4 +1,6 @@
-﻿using Refit;
+﻿using Microsoft.Extensions.Logging;
+using Polly.CircuitBreaker;
+using Refit;
 using SecureVault.App.Application.Contracts.Abstractions.Api;
 using SecureVault.App.Application.Contracts.DTOs.Session;
 using SecureVault.Shared.Result;
@@ -9,10 +11,12 @@ namespace SecureVault.App.Infrastructure.Services.Api
     public class UserSessionService : IUserSessionService
     {
         private readonly ISecureVaultAuthorizeApi _secureVaultApi;
+        private readonly ILogger<UserSessionService> _logger;
 
-        public UserSessionService(ISecureVaultAuthorizeApi secureVaultApi)
+        public UserSessionService(ISecureVaultAuthorizeApi secureVaultApi, ILogger<UserSessionService> logger)
         {
             _secureVaultApi = secureVaultApi;
+            _logger = logger;
         }
 
         public async Task<Result<List<UserSessionsDto>>> GetUserSessionsAsync(CancellationToken cancellationToken)
@@ -22,10 +26,26 @@ namespace SecureVault.App.Infrastructure.Services.Api
                 var sessions = await _secureVaultApi.GetUserSessionsAsync(cancellationToken);
                 return sessions;
             }
+            catch (BrokenCircuitException)
+            {
+                _logger.LogError("Devre açık. Kullanıcı oturumları alınamadı.");
+                return Result<List<UserSessionsDto>>.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor. Lütfen birkaç dakika sonra tekrar deneyin."));
+            }
             catch (ApiException ex)
             {
+                _logger.LogError(ex, "Kullanıcı oturumları alınırken API hatası. Durum Kodu: {StatusCode}", ex.StatusCode);
                 var error = await ex.GetContentAsAsync<Error>();
-                return Result<List<UserSessionsDto>>.Failure(error ?? new Error("Client.LoadFailed", "Oturumlar yüklenemedi."));
+                return Result<List<UserSessionsDto>>.Failure(error ?? new Error("Api.RequestFailed", "Oturumlar yüklenemedi."));
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Kullanıcı oturumları alınırken ağ hatası.");
+                return Result<List<UserSessionsDto>>.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı. Lütfen internet bağlantınızı kontrol edin."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Kullanıcı oturumları alınırken beklenmedik bir hata oluştu.");
+                return Result<List<UserSessionsDto>>.Failure(new Error("Client.UnexpectedError", "Beklenmedik bir hata oluştu."));
             }
         }
 
@@ -39,10 +59,26 @@ namespace SecureVault.App.Infrastructure.Services.Api
                     ? Result.Success()
                     : Result.Failure(await response.Error.GetContentAsAsync<Error>() ?? new Error("Client.DeleteFailed", "Oturum sonlandırılamadı."));
             }
+            catch (BrokenCircuitException)
+            {
+                _logger.LogError("Devre açık. Oturum sonlandırılamadı.");
+                return Result.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor. Lütfen birkaç dakika sonra tekrar deneyin."));
+            }
             catch (ApiException ex)
             {
+                _logger.LogError(ex, "Oturum sonlandırılırken API hatası. Durum Kodu: {StatusCode}", ex.StatusCode);
                 var error = await ex.GetContentAsAsync<Error>();
                 return Result.Failure(error ?? new Error("Client.DeleteFailed", "Oturum sonlandırılamadı."));
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Oturum sonlandırılırken ağ hatası.");
+                return Result.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı. Lütfen internet bağlantınızı kontrol edin."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Oturum sonlandırılırken beklenmedik bir hata oluştu.");
+                return Result.Failure(new Error("Client.UnexpectedError", "Beklenmedik bir hata oluştu."));
             }
         }
     }

--- a/src/clients/SecureVault.App.Infrastructure/Services/Api/VaultItemService.cs
+++ b/src/clients/SecureVault.App.Infrastructure/Services/Api/VaultItemService.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Polly.CircuitBreaker;
 using Refit;
 using SecureVault.App.Application.Contracts.Abstractions.Api;
 using SecureVault.App.Application.Contracts.DTOs.VaultItem;
@@ -16,6 +17,7 @@ namespace SecureVault.App.Infrastructure.Services.Api
             _secureVaultApi = secureVaultApi;
             _logger = logger;
         }
+
         public async Task<Result<IReadOnlyCollection<VaultItemDto>>> GetUserVaultAsync(CancellationToken cancellationToken)
         {
             try
@@ -23,10 +25,26 @@ namespace SecureVault.App.Infrastructure.Services.Api
                 var vaultItems = await _secureVaultApi.GetUserVaultAsync(cancellationToken);
                 return Result<IReadOnlyCollection<VaultItemDto>>.Success(vaultItems);
             }
+            catch (BrokenCircuitException)
+            {
+                _logger.LogError("Devre açık. Kasa verileri alınamadı.");
+                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor."));
+            }
             catch (ApiException ex)
             {
+                _logger.LogError(ex, "Kasa verileri alınırken API hatası oluştu.");
                 var error = await ex.GetContentAsAsync<Error>();
-                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(error ?? new Error("Client.LoadFailed", "Veriler yüklenemedi."));
+                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(error ?? new Error("Api.RequestFailed", "Veriler yüklenemedi."));
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Kasa verileri alınırken ağ hatası oluştu.");
+                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Kasa verileri alınırken beklenmedik bir hata oluştu.");
+                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(new Error("Client.UnexpectedError", "Beklenmedik bir hata oluştu."));
             }
         }
 
@@ -37,10 +55,26 @@ namespace SecureVault.App.Infrastructure.Services.Api
                 var encryptedItems = await _secureVaultApi.GetVaultItemsByItemTypeAsync(itemType, cancellationToken);
                 return Result<IReadOnlyCollection<VaultItemDto>>.Success(encryptedItems);
             }
+            catch (BrokenCircuitException)
+            {
+                _logger.LogError("Devre açık. Kasa verileri türe göre alınamadı.");
+                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor."));
+            }
             catch (ApiException ex)
             {
+                _logger.LogError(ex, "Kasa verileri türe göre alınırken API hatası oluştu.");
                 var error = await ex.GetContentAsAsync<Error>();
-                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(error ?? new Error("Client.LoadFailed", "Veriler yüklenemedi."));
+                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(error ?? new Error("Api.RequestFailed", "Veriler yüklenemedi."));
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Kasa verileri türe göre alınırken ağ hatası oluştu.");
+                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Kasa verileri türe göre alınırken beklenmedik bir hata oluştu.");
+                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(new Error("Client.UnexpectedError", "Beklenmedik bir hata oluştu."));
             }
         }
 
@@ -49,16 +83,30 @@ namespace SecureVault.App.Infrastructure.Services.Api
             try
             {
                 var response = await _secureVaultApi.CreateVaultItemAsync(createVaultItemDto, cancellationToken);
-
                 return response.IsSuccessStatusCode
                     ? Result.Success()
                     : Result.Failure(await response.Error.GetContentAsAsync<Error>() ?? new Error("Client.CreationFailed", "Öğe oluşturulamadı."));
             }
+            catch (BrokenCircuitException)
+            {
+                _logger.LogError("Devre açık. Kasa öğesi oluşturulamadı.");
+                return Result.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor."));
+            }
             catch (ApiException ex)
             {
-                var errorContent = ex.Content;
-                System.Diagnostics.Debug.WriteLine($"API'den gelen ham hata içeriği: {errorContent}");
-                return Result.Failure(new Error("Client.ApiError", $"API Yanıtı Okunamadı: {errorContent}"));
+                _logger.LogError(ex, "Kasa öğesi oluşturulurken API hatası oluştu.");
+                var error = await ex.GetContentAsAsync<Error>();
+                return Result.Failure(error ?? new Error("Api.RequestFailed", "Öğe oluşturulamadı."));
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Kasa öğesi oluşturulurken ağ hatası oluştu.");
+                return Result.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Kasa öğesi oluşturulurken beklenmedik bir hata oluştu.");
+                return Result.Failure(new Error("Client.UnexpectedError", "Beklenmedik bir hata oluştu."));
             }
         }
 
@@ -66,20 +114,31 @@ namespace SecureVault.App.Infrastructure.Services.Api
         {
             try
             {
-                //var encryptionKey = await GetEncryptionKeyAsync();
-                //var encryptedData = _cryptoService.Encrypt(data, encryptionKey); 
-
                 var response = await _secureVaultApi.UpdateVaultItemAsync(updateEncryptedData, cancellationToken);
-
                 return response.IsSuccessStatusCode
                     ? Result.Success()
                     : Result.Failure(await response.Error.GetContentAsAsync<Error>() ?? new Error("Client.UpdateFailed", "Öğe güncellenemedi."));
             }
+            catch (BrokenCircuitException)
+            {
+                _logger.LogError("Devre açık. Kasa öğesi güncellenemedi.");
+                return Result.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor."));
+            }
             catch (ApiException ex)
             {
-                _logger.LogError(ex, "Vault item güncellenirken bir hata oluştu. Id: {Id}", updateEncryptedData.Id);
+                _logger.LogError(ex, "Kasa öğesi güncellenirken API hatası oluştu.");
                 var error = await ex.GetContentAsAsync<Error>();
-                return Result.Failure(error ?? new Error("Client.UpdateFailed", "Öğe güncellenemedi."));
+                return Result.Failure(error ?? new Error("Api.RequestFailed", "Öğe güncellenemedi."));
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Kasa öğesi güncellenirken ağ hatası oluştu.");
+                return Result.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Kasa öğesi güncellenirken beklenmedik bir hata oluştu.");
+                return Result.Failure(new Error("Client.UnexpectedError", "Beklenmedik bir hata oluştu."));
             }
         }
 
@@ -92,10 +151,26 @@ namespace SecureVault.App.Infrastructure.Services.Api
                     ? Result.Success()
                     : Result.Failure(await response.Error.GetContentAsAsync<Error>() ?? new Error("Client.DeletionFailed", "Öğe silinemedi."));
             }
+            catch (BrokenCircuitException)
+            {
+                _logger.LogError("Devre açık. Kasa öğesi silinemedi.");
+                return Result.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor."));
+            }
             catch (ApiException ex)
             {
+                _logger.LogError(ex, "Kasa öğesi silinirken API hatası oluştu.");
                 var error = await ex.GetContentAsAsync<Error>();
-                return Result.Failure(error ?? new Error("Client.DeletionFailed", "Öğe silinemedi."));
+                return Result.Failure(error ?? new Error("Api.RequestFailed", "Öğe silinemedi."));
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Kasa öğesi silinirken ağ hatası oluştu.");
+                return Result.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Kasa öğesi silinirken beklenmedik bir hata oluştu.");
+                return Result.Failure(new Error("Client.UnexpectedError", "Beklenmedik bir hata oluştu."));
             }
         }
 
@@ -106,10 +181,26 @@ namespace SecureVault.App.Infrastructure.Services.Api
                 var vaultItems = await _secureVaultApi.GetVaultItemByLastSyncTimeAsync(lastUpdateTime, cancellationToken);
                 return Result<IReadOnlyCollection<VaultItemDto>>.Success(vaultItems);
             }
+            catch (BrokenCircuitException)
+            {
+                _logger.LogError("Devre açık. Senkronizasyon için veriler alınamadı.");
+                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(new Error("Service.Unavailable", "Servis geçici olarak kullanılamıyor."));
+            }
             catch (ApiException ex)
             {
+                _logger.LogError(ex, "Senkronizasyon için veri alınırken API hatası oluştu.");
                 var error = await ex.GetContentAsAsync<Error>();
-                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(error ?? new Error("Client.LoadFailed", "Veriler yüklenemedi."));
+                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(error ?? new Error("Api.RequestFailed", "Veriler yüklenemedi."));
+            }
+            catch (HttpRequestException ex)
+            {
+                _logger.LogError(ex, "Senkronizasyon için veri alınırken ağ hatası oluştu.");
+                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(new Error("Service.ConnectionError", "Sunucuya bağlanılamadı."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Senkronizasyon için veri alınırken beklenmedik bir hata oluştu.");
+                return Result<IReadOnlyCollection<VaultItemDto>>.Failure(new Error("Client.UnexpectedError", "Beklenmedik bir hata oluştu."));
             }
         }
     }

--- a/src/clients/SecureVault.App.Infrastructure/Services/QrCodeLogin/QrLoginOrchestratorService.cs
+++ b/src/clients/SecureVault.App.Infrastructure/Services/QrCodeLogin/QrLoginOrchestratorService.cs
@@ -55,10 +55,10 @@ namespace SecureVault.App.Infrastructure.Services.QrCodeLogin
 
                 if (method == InitiationMethod.GenerateQrCode)
                 {
-                    _channelId = await _interactionService.CreateQrLoginChannelAsync(cancellationToken);
+                    var response = await _interactionService.CreateQrLoginChannelAsync(cancellationToken);
                     if (string.IsNullOrEmpty(_channelId))
                         throw new InvalidOperationException("Sunucudan kanal ID'si alınamadı.");
-
+                    _channelId = response.Value;
                     await SafeInvokeAsync(() => OnQrCodeAvailable?.Invoke(_channelId));
                 }
                 else


### PR DESCRIPTION
## 📝 Summary
This PR integrates the **Polly** library into the client's HTTP communication pipeline to introduce robust resiliency patterns. It makes the application significantly more stable by gracefully handling transient network errors and temporary service unavailability.

## 🎯 Motivation
The client was previously vulnerable to failures when the backend API was slow, temporarily down, or returned transient errors (e.g., 503 Service Unavailable). This led to an abrupt and poor user experience. The primary goal is to make the client resilient, allowing it to recover from temporary issues automatically and provide clearer feedback to the user when a service is genuinely unavailable.

## ✨ Key Technical Changes
* A new `PollyResiliencyHandler` has been implemented as a `DelegatingHandler` to intercept all outgoing API requests.
* A combined resiliency strategy has been configured using `PolicyWrap`:
    * **Retry Policy:** An exponential backoff retry strategy that attempts a request up to 3 times on transient HTTP errors (`5xx`, `408`) and `429 Too Many Requests`.
    * **Circuit Breaker Policy:** After 5 consecutive failures, the circuit opens for 30 seconds, preventing further calls to a known-failing service and allowing it time to recover.
* `HttpClient` is now configured to use this resiliency handler for all API clients.
* API service classes (e.g., `InteractionService`) have been refactored with detailed `try-catch` blocks to handle specific exceptions like `BrokenCircuitException` and `ApiException`.

## 🔄 Related Architectural Changes
* As part of making error handling more explicit, methods in the API service layer now return a `Result<T>` object instead of raw types. This change enforces a structured success/failure handling pattern in the application layer and prevents unhandled exceptions from propagating upwards.