### PR TITLE
feat(sync): Exclude originating device from sync notifications

### DIFF
--- a/src/services/Interaction/SecureVault.Interaction.Api/Features/Sync/Contracts/INotificationService.cs
+++ b/src/services/Interaction/SecureVault.Interaction.Api/Features/Sync/Contracts/INotificationService.cs
@@ -2,6 +2,6 @@
 {
     public interface INotificationService
     {
-        Task NotifyClientsForSync(Guid userId);
+        Task NotifyClientsForSync(Guid userId, string originDeviceId);
     }
 }

--- a/src/services/Interaction/SecureVault.Interaction.Api/Features/Sync/Contracts/IUserConnectionManager.cs
+++ b/src/services/Interaction/SecureVault.Interaction.Api/Features/Sync/Contracts/IUserConnectionManager.cs
@@ -2,8 +2,8 @@
 {
     public interface IUserConnectionManager
     {
-        void AddConnection(Guid userId, string connectionId);
+        void AddConnection(Guid userId, string connectionId, string deviceId);
         Guid? RemoveConnection(string connectionId);
-        IReadOnlyList<string> GetConnections(Guid userId);
+        IReadOnlyList<string> GetConnections(Guid userId, string? deviceIdToExclude = null);
     }
 }

--- a/src/services/Interaction/SecureVault.Interaction.Api/Features/Sync/EventHandlers/UserActivityOccurredIntegrationEventHandler.cs
+++ b/src/services/Interaction/SecureVault.Interaction.Api/Features/Sync/EventHandlers/UserActivityOccurredIntegrationEventHandler.cs
@@ -18,8 +18,8 @@ namespace SecureVault.Interaction.Api.Features.Sync.EventHandlers
 
         public async Task Handle(UserActivityOccurredIntegrationEvent @event)
         {
-            _logger.LogInformation("UserId: {UserId} için senkronizasyon bildirimi gönderiliyor.", @event.UserId);
-            await _notificationService.NotifyClientsForSync(@event.UserId);
+            _logger.LogInformation("UserId: {UserId} için senkronizasyon bildirimi gönderiliyor. Kaynak Cihaz: {DeviceId}", @event.UserId, @event.OriginDeviceId);
+            await _notificationService.NotifyClientsForSync(@event.UserId, @event.OriginDeviceId);
         }
     }
 }

--- a/src/services/Interaction/SecureVault.Interaction.Api/Features/Sync/Hubs/SyncHub.cs
+++ b/src/services/Interaction/SecureVault.Interaction.Api/Features/Sync/Hubs/SyncHub.cs
@@ -20,8 +20,9 @@ namespace SecureVault.Interaction.Api.Features.Sync.Hubs
         public override Task OnConnectedAsync()
         {
             var userId = GetUserIdFromContext();
+            var deviceId = GetDeviceIdFromContext();
             var connectionId = Context.ConnectionId; 
-            _userConnectionManager.AddConnection(userId, connectionId);
+            _userConnectionManager.AddConnection(userId, connectionId, deviceId);
             _logger.LogInformation("Kullanıcı bağlandı. UserId: {UserId}, ConnectionId: {ConnectionId}", userId, connectionId);
             return base.OnConnectedAsync();
         }
@@ -59,6 +60,18 @@ namespace SecureVault.Interaction.Api.Features.Sync.Hubs
                 throw new InvalidOperationException("Geçerli bir kullanıcı kimliği bulunamadı.");
             }
             return userId;
+        }
+
+        private string GetDeviceIdFromContext()
+        {
+            var httpContext = Context.GetHttpContext();
+            var deviceId = httpContext?.Request.Headers["X-Device-Id"].ToString();
+
+            if (string.IsNullOrEmpty(deviceId))
+            {
+                throw new InvalidOperationException("Geçerli bir cihaz kimliği ('X-Device-ID' header) bulunamadı.");
+            }
+            return deviceId;
         }
     }
 }

--- a/src/services/Interaction/SecureVault.Interaction.Api/Features/Sync/Services/InMemoryUserConnectionManager.cs
+++ b/src/services/Interaction/SecureVault.Interaction.Api/Features/Sync/Services/InMemoryUserConnectionManager.cs
@@ -5,15 +5,17 @@ namespace SecureVault.Interaction.Api.Features.Sync.Services
 {
     public class InMemoryUserConnectionManager : IUserConnectionManager
     {
-        private static readonly ConcurrentDictionary<Guid, HashSet<string>> _userConnections = new();
+        private record Connection(string ConnectionId, string DeviceId);
+
+        private static readonly ConcurrentDictionary<Guid, HashSet<Connection>> _userConnections = new();
         private static readonly ConcurrentDictionary<string, Guid> _connectionUsers = new();
 
-        public void AddConnection(Guid userId, string connectionId)
+        public void AddConnection(Guid userId, string connectionId, string deviceId)
         {
             var connections = _userConnections.GetOrAdd(userId, _ => []);
             lock (connections)
             {
-                connections.Add(connectionId);
+                connections.Add(new Connection(connectionId, deviceId));
             }
             _connectionUsers.TryAdd(connectionId, userId);
         }
@@ -26,24 +28,29 @@ namespace SecureVault.Interaction.Api.Features.Sync.Services
                 {
                     lock (connections)
                     {
-                        connections.Remove(connectionId);
+                        var connectionToRemove = connections.FirstOrDefault(c => c.ConnectionId == connectionId);
+                        if (connectionToRemove is not null)
+                            connections.Remove(connectionToRemove);
+
                         if (!connections.Any())
-                        {
                             _userConnections.TryRemove(userId, out _);
-                        }
                     }
                 }
                 return userId;
             }
             return null;
         }
-        public IReadOnlyList<string> GetConnections(Guid userId)
+        public IReadOnlyList<string> GetConnections(Guid userId, string? deviceIdToExclude = null)
         {
             if (_userConnections.TryGetValue(userId, out var connections))
             {
                 lock (connections)
                 {
-                    return [.. connections];
+                    IEnumerable<Connection> query = connections;
+                    if (!string.IsNullOrEmpty(deviceIdToExclude))
+                        query = query.Where(c => c.DeviceId != deviceIdToExclude);
+
+                    return [.. query.Select(c => c.ConnectionId)];
                 }
             }
             return [];

--- a/src/services/Interaction/SecureVault.Interaction.Api/Features/Sync/Services/SignalRNotificationService.cs
+++ b/src/services/Interaction/SecureVault.Interaction.Api/Features/Sync/Services/SignalRNotificationService.cs
@@ -17,9 +17,9 @@ namespace SecureVault.Interaction.Api.Features.Sync.Services
             _userConnectionManager = userConnectionManager;
         }
 
-        public async Task NotifyClientsForSync(Guid userId)
+        public async Task NotifyClientsForSync(Guid userId, string originDeviceId)
         {
-            var connections = _userConnectionManager.GetConnections(userId);
+            var connections = _userConnectionManager.GetConnections(userId, originDeviceId);
 
             if (connections is not null && connections.Any())
             {

--- a/src/services/Vault/SecureVault.Vault.Application/Features/CQRS/VaultItems/Handlers/CreateVaultItemHandler.cs
+++ b/src/services/Vault/SecureVault.Vault.Application/Features/CQRS/VaultItems/Handlers/CreateVaultItemHandler.cs
@@ -40,7 +40,7 @@ namespace SecureVault.Vault.Application.Features.CQRS.VaultItems.Handlers
 
                 await _repository.AddAsync(vaultItem);
 
-                var itemUpdatedEvent = new UserActivityOccurredIntegrationEvent(vaultItem.UserId);
+                var itemUpdatedEvent = new UserActivityOccurredIntegrationEvent(vaultItem.UserId, request.LastUpdatedByDeviceId);
                 await _eventPublisher.PublishAsync(itemUpdatedEvent, "vault.item.created", cancellationToken);
 
                 return Result.Success();

--- a/src/services/Vault/SecureVault.Vault.Application/Features/CQRS/VaultItems/Handlers/DeleteVaultItemHandler.cs
+++ b/src/services/Vault/SecureVault.Vault.Application/Features/CQRS/VaultItems/Handlers/DeleteVaultItemHandler.cs
@@ -45,7 +45,7 @@ namespace SecureVault.Vault.Application.Features.CQRS.VaultItems.Handlers
                 vaultItem.Delete(request.LastUpdatedByDeviceId);
                 await _repository.UpdateAsync(vaultItem);
 
-                var itemUpdatedEvent = new UserActivityOccurredIntegrationEvent(vaultItem.UserId);
+                var itemUpdatedEvent = new UserActivityOccurredIntegrationEvent(vaultItem.UserId, request.LastUpdatedByDeviceId);
                 await _eventPublisher.PublishAsync(itemUpdatedEvent, "vault.item.created", cancellationToken);
 
                 return Result.Success();

--- a/src/services/Vault/SecureVault.Vault.Application/Features/CQRS/VaultItems/Handlers/UpdateVaultItemHandler.cs
+++ b/src/services/Vault/SecureVault.Vault.Application/Features/CQRS/VaultItems/Handlers/UpdateVaultItemHandler.cs
@@ -45,7 +45,7 @@ namespace SecureVault.Vault.Application.Features.CQRS.VaultItems.Handlers
                 vaultItem.UpdateData(request.EncryptedData, request.UpdatedAt, request.LastUpdatedByDeviceId);
                 await _repository.UpdateAsync(vaultItem);
 
-                var itemUpdatedEvent = new UserActivityOccurredIntegrationEvent(vaultItem.UserId);
+                var itemUpdatedEvent = new UserActivityOccurredIntegrationEvent(vaultItem.UserId, request.LastUpdatedByDeviceId);
                 await _eventPublisher.PublishAsync(itemUpdatedEvent, "vault.item.created", cancellationToken);
 
                 return Result.Success();

--- a/src/shared/SecureVault.Shared.RabbitMQ/Events/UserActivityOccurredIntegrationEvent.cs
+++ b/src/shared/SecureVault.Shared.RabbitMQ/Events/UserActivityOccurredIntegrationEvent.cs
@@ -1,4 +1,4 @@
 ﻿namespace SecureVault.Shared.Contracts.Events
 {
-    public record UserActivityOccurredIntegrationEvent(Guid UserId) : BaseIntegrationEvent;
+    public record UserActivityOccurredIntegrationEvent(Guid UserId, string OriginDeviceId) : BaseIntegrationEvent;
 }


### PR DESCRIPTION
## 📝 Summary
This PR enhances the server-to-client synchronization logic to be **device-aware**, preventing the device that initiated an action from receiving its own redundant sync notification. The entire notification pipeline, from the event publication in the CQRS handlers to the SignalR hub connection management, has been updated to track and utilize the originating device's ID.

## 🎯 Motivation
Previously, when a user action on **Device A** triggered a `UserActivityOccurredIntegrationEvent`, the notification system would broadcast a `SyncRequired` message to *all* of that user's connected devices, including **Device A**. This was inefficient for several reasons:
* **Redundant Network Traffic:** It sent an unnecessary message to the client that was already up-to-date.
* **Unnecessary Client-Side Logic:** The client would receive the notification and potentially trigger a data fetch for information it already possessed.
* **Potential for Race Conditions:** Could lead to complex UI state management if the client tries to sync while already processing the user's initial action.

The goal is to make the sync process more intelligent and efficient by notifying only the user's *other* devices.

## ✨ Key Technical Changes
1.  **Event Contract:** The `UserActivityOccurredIntegrationEvent` has been updated to include an `OriginDeviceId` property.
2.  **Event Publication:** All relevant CQRS handlers (`Create`, `Update`, `Delete` handlers for vault items) now capture the `LastUpdatedByDeviceId` from the command and publish it within the integration event.
3.  **SignalR Hub Connection:** The `SyncHub` now reads the `X-Device-Id` header from the client's connection request and stores this `deviceId` alongside the `userId` and `connectionId` in the `UserConnectionManager`.
4.  **Connection Management:** The `IUserConnectionManager` interface and its implementation have been updated to accept and store the `deviceId`. Its `GetConnections` method now includes an optional `deviceIdToExclude` parameter to filter out the originating device.
5.  **Notification Service:** The `SignalRNotificationService` now passes the `originDeviceId` to the connection manager, ensuring that the list of recipients correctly excludes the sender.

### 📊 Flow Comparison

**Before:**
`Action on Device A` → `Event(UserId)` → `Get all connections for UserId` → `Notify Device A, B, C`

**After:**
`Action on Device A` → `Event(UserId, DeviceId_A)` → `Get all connections for UserId EXCEPT DeviceId_A` → `Notify Device B, C`