### PR TITLE
fix(infra): Correct YARP routing and simplify client SSL configuration

### DIFF
--- a/src/clients/SecureVault.App.Infrastructure/Helpers/ApiSettings.cs
+++ b/src/clients/SecureVault.App.Infrastructure/Helpers/ApiSettings.cs
@@ -3,6 +3,5 @@
     public class ApiSettings
     {
         public string BaseUrl { get; set; } = string.Empty;
-        public string DevMachineName { get; set; } = string.Empty;
     }
 }

--- a/src/clients/SecureVault.App.Infrastructure/HttpHandlers/HttpHandlerPipelineBuilder.cs
+++ b/src/clients/SecureVault.App.Infrastructure/HttpHandlers/HttpHandlerPipelineBuilder.cs
@@ -7,11 +7,17 @@ namespace SecureVault.App.Infrastructure.HttpHandlers
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly ApiSettings _apiSettings;
+        private readonly string _devHost;
 
         public HttpHandlerPipelineBuilder(IServiceProvider serviceProvider, IOptions<ApiSettings> apiSettings)
         {
             _serviceProvider = serviceProvider;
             _apiSettings = apiSettings.Value;
+            _devHost = string.Empty;
+            if (!string.IsNullOrEmpty(_apiSettings.BaseUrl) && Uri.TryCreate(_apiSettings.BaseUrl, UriKind.Absolute, out var baseUri))
+            {
+                _devHost = baseUri.Host;
+            }
         }
 
         public DelegatingHandler CreatePipeline()
@@ -21,10 +27,9 @@ namespace SecureVault.App.Infrastructure.HttpHandlers
                 ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
                 {
 #if DEBUG
-                    var machineName = _apiSettings.DevMachineName;
-                    if (!string.IsNullOrEmpty(machineName) && message.RequestUri.Host.Equals(machineName, StringComparison.OrdinalIgnoreCase))
+                    if (!string.IsNullOrEmpty(_devHost) && message.RequestUri.Host.Equals(_devHost, StringComparison.OrdinalIgnoreCase))
                     {
-                        Console.WriteLine($"[SSL-DEBUG] Certificate validation bypassed for {machineName} via PipelineBuilder.");
+                        Console.WriteLine($"[SSL-DEBUG] Certificate validation bypassed for {_devHost} via PipelineBuilder.");
                         return true;
                     }
 #endif

--- a/src/clients/SecureVault.App.Infrastructure/InfrastructureServiceRegistration.cs
+++ b/src/clients/SecureVault.App.Infrastructure/InfrastructureServiceRegistration.cs
@@ -98,21 +98,34 @@ namespace SecureVault.App.Infrastructure
                     ?? throw new InvalidOperationException("ApiSettings not found.");
 
             //refit
-            static HttpClientHandler configureHandler(string machineName) => new()
+            static HttpClientHandler configureHandler(string baseUrl)
             {
-                SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
-                ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
+                string devHost = string.Empty;
+                if (!string.IsNullOrEmpty(baseUrl) &&
+                        Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri))
                 {
-#if DEBUG
-                    if (message.RequestUri.Host.Equals(machineName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        Console.WriteLine($"[SSL-DEBUG] Certificate validation bypassed for local dev host: {machineName}");
-                        return true;
-                    }
-#endif
-                    return errors == SslPolicyErrors.None;
+                    devHost = baseUri.Host;
                 }
-            };
+
+                return new()
+                {
+                    SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                    ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
+                    {
+#if DEBUG
+                        // Kontrolü artık devHost üzerinden yap
+                        if (!string.IsNullOrEmpty(devHost) &&
+                            message.RequestUri.Host.Equals(devHost, StringComparison.OrdinalIgnoreCase))
+                        {
+                            Console.WriteLine($"[SSL-DEBUG] Certificate validation bypassed for local dev host: {devHost}");
+                            return true;
+                        }
+#endif
+                        return errors == SslPolicyErrors.None;
+                    }
+                };
+            }
+
             RefitSettings refitSettings = new()
             {
                 ContentSerializer = new SystemTextJsonContentSerializer(new JsonSerializerOptions
@@ -131,14 +144,14 @@ namespace SecureVault.App.Infrastructure
                     .AddHttpMessageHandler<PollyResiliencyHandler>()
                     .AddHttpMessageHandler<DeviceHeadersHandler>()
                     .AddHttpMessageHandler<AuthTokenHandler>()
-                    .ConfigurePrimaryHttpMessageHandler(() => configureHandler(apiSettings.DevMachineName));
+                    .ConfigurePrimaryHttpMessageHandler(() => configureHandler(apiSettings.BaseUrl));
 
             services.AddRefitClient<ISecureVaultAnonymousApi>(refitSettings)
                     .ConfigureHttpClient(configureClient)
                     .AddHttpMessageHandler<PollyResiliencyHandler>()
                     .AddHttpMessageHandler<DeviceHeadersHandler>()
                     .AddHttpMessageHandler<AddBearerTokenHandler>()
-                    .ConfigurePrimaryHttpMessageHandler(() => configureHandler(apiSettings.DevMachineName));
+                    .ConfigurePrimaryHttpMessageHandler(() => configureHandler(apiSettings.BaseUrl));
 
             return services;
         }

--- a/src/clients/SecureVault.App/appsettings.json
+++ b/src/clients/SecureVault.App/appsettings.json
@@ -1,7 +1,6 @@
 {
   "ApiSettings": {
-    "BaseUrl": "https://your-device-name-here:7202/",
-    "DevMachineName": "your-device-name-here"
+    "BaseUrl": "https://use-your-local-ip-with-gateway-port-or-use-forwarded-ports/"
   },
   "SignalRSettings": {
     "HubPath": "/interaction/hubs/synchub"

--- a/src/gateways/SecureVault.ApiGateway/yarp.json
+++ b/src/gateways/SecureVault.ApiGateway/yarp.json
@@ -2,7 +2,7 @@
   "ReverseProxy": {
     "Routes": {
       "interaction-route": {
-        "ClusterId": "interaction-http-cluster",
+        "ClusterId": "interaction-cluster",
         "Match": {
           "Path": "/interaction/{**everything}",
           "Methods": [


### PR DESCRIPTION
This commit includes follow-up fixes after the .NET Aspire migration:

1.  **YARP Routing Fix:** Corrected a misconfigured `ClusterId` in the YARP `appsettings.json`. The `interaction-route` was pointing to a non-existent `interaction-http-cluster`. This has been fixed to point to the correct `interaction-cluster`, restoring connectivity to the Interaction service.

2.  **Client Config Simplification:** Removed the redundant `DevMachineName` setting from `ApiSettings` and `appsettings.json`. The local development SSL bypass logic in `HttpHandlerPipelineBuilder` and `InfrastructureServiceRegistration` now intelligently parses the hostname directly from the `BaseUrl`. This simplifies setup and removes a redundant configuration entry.