### PR TITLE
fix(interaction): Set AbortOnConnectFail=false to fix Redis connection error

### DIFF
--- a/src/services/Interaction/SecureVault.Interaction.Api/Program.cs
+++ b/src/services/Interaction/SecureVault.Interaction.Api/Program.cs
@@ -5,6 +5,7 @@ using SecureVault.Interaction.Api.Features.Interaction;
 using SecureVault.Interaction.Api.Features.QrLogin;
 using SecureVault.Interaction.Api.Helpers;
 using Serilog;
+using StackExchange.Redis;
 using System.Text;
 
 namespace SecureVault.Interaction.Api
@@ -74,7 +75,16 @@ namespace SecureVault.Interaction.Api
                     });
             });
 
-            builder.Services.AddSignalR().AddStackExchangeRedis("redis-cache");
+            builder.Services.AddSignalR().AddStackExchangeRedis(options =>
+            {
+                var connectionString = builder.Configuration.GetConnectionString("redis-cache");
+
+                if (string.IsNullOrEmpty(connectionString))
+                    throw new InvalidOperationException("Redis bağlantı dizesi 'redis-cache' bulunamadı.");
+
+                options.Configuration = ConfigurationOptions.Parse(connectionString);
+                options.Configuration.AbortOnConnectFail = false;
+            });
             builder.Services.AddAuthorization();
 
 


### PR DESCRIPTION
Updated the SignalR Redis Backplane configuration to resolve the `RedisConnectionException`. As suggested by the error log, `AbortOnConnectFail` is set to `false`.

This prevents the service from crashing if it starts before Redis is ready (e.g., during Aspire startup) and allows it to retry connecting in the background. The configuration was also updated to use the options pattern to parse the connection string from `IConfiguration`.