### PR TITLE
feat(infra): Add Prometheus/Grafana metrics and complete the observability (logging/tracing) stack

### DIFF
--- a/grafana/config/grafana.ini
+++ b/grafana/config/grafana.ini
@@ -1,0 +1,16 @@
+[auth.anonymous]
+enabled = true
+
+# Organization name that should be used for unauthenticated users
+org_name = Main Org.
+
+# Role for unauthenticated users, other valid values are `Editor` and `Admin`
+org_role = Admin
+
+# Hide the Grafana version text from the footer and help tooltip for unauthenticated users (default: false)
+hide_version = true
+
+[dashboards]
+default_home_dashboard_path = /var/lib/grafana/dashboards/aspnetcore.json
+
+min_refresh_interval = 1s

--- a/grafana/config/provisioning/dashboards/default.yaml
+++ b/grafana/config/provisioning/dashboards/default.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: Default
+    folder: .NET
+    type: file
+    options:
+      path:
+        /var/lib/grafana/dashboards

--- a/grafana/config/provisioning/datasources/default.yaml
+++ b/grafana/config/provisioning/datasources/default.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    # Access mode - proxy (server in the UI) or direct (browser in the UI).
+    url: $PROMETHEUS_ENDPOINT
+    uid: PBFA97CFB590B2093

--- a/grafana/dashboards/aspnetcore-endpoint.json
+++ b/grafana/dashboards/aspnetcore-endpoint.json
@@ -1,0 +1,952 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "ASP.NET Core endpoint metrics from OpenTelemetry",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": " ASP.NET Core",
+      "tooltip": "",
+      "type": "link",
+      "url": "/d/KdDACDp4z/asp-net-core-metrics"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-green",
+            "mode": "continuous-GrYlRd",
+            "seriesBy": "max"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "index": 0,
+                  "text": "0 ms"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "p50"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p75",
+          "range": true,
+          "refId": "p75"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "p90"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.98, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p98",
+          "range": true,
+          "refId": "p98"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "p99"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.999, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p99.9",
+          "range": true,
+          "refId": "p99.9"
+        }
+      ],
+      "title": "Requests Duration - $method $route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic",
+            "seriesBy": "max"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "index": 0,
+                  "text": "0%"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "All"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4XX"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5XX"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\", http_response_status_code=~\"4..|5..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval]))",
+          "legendFormat": "All",
+          "range": true,
+          "refId": "All"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\", http_response_status_code=~\"4..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "4XX",
+          "range": true,
+          "refId": "4XX"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\", http_response_status_code=~\"5..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "5XX",
+          "range": true,
+          "refId": "5XX"
+        }
+      ],
+      "title": "Errors Rate - $method $route",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-YlRd"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Route"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "",
+                    "url": "/d/NagEsjE4z/asp-net-core-endpoint-details?var-route=${__data.fields.Route}&var-method=${__data.fields.Method}&${__url_time_range}"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "hideTimeOverride": false,
+      "id": 44,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum by (error_type) (\r\n  ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\", error_type!=\"\"}[$__range]))\r\n)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{route}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Unhandled Exceptions",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "method": false
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 2,
+              "error_type": 1
+            },
+            "renameByName": {
+              "Value": "Requests",
+              "error_type": "Exception",
+              "http_request_method": "Method",
+              "http_route": "Route"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (http_response_status_code) (\r\n    ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__range]))\r\n  )",
+          "legendFormat": "Status {{http_response_status_code}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests HTTP Status Code",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 13
+      },
+      "id": 48,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (url_scheme) (\r\n    ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__range]))\r\n  )",
+          "legendFormat": "{{scheme}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests Secured",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 13
+      },
+      "id": 50,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (method_route) (\r\n    label_replace(ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route=\"$route\", http_request_method=\"$method\"}[$__range])), \"method_route\", \"http/$1\", \"network_protocol_version\", \"(.*)\")\r\n  )",
+          "legendFormat": "{{protocol}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests HTTP Protocol",
+      "type": "stat"
+    }
+  ],
+  "refresh": "10s",
+  "revision": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "dotnet",
+    "prometheus",
+    "aspnetcore"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "label_values(http_server_active_requests,job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_active_requests,job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "label_values(http_server_active_requests{job=~\"$job\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_active_requests{job=~\"$job\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "label_values(http_server_request_duration_seconds_count,http_route)",
+        "description": "Route",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Route",
+        "multi": false,
+        "name": "route",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_request_duration_seconds_count,http_route)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "label_values(http_server_request_duration_seconds_count{http_route=~\"$route\"},http_request_method)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Method",
+        "multi": false,
+        "name": "method",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_request_duration_seconds_count{http_route=~\"$route\"},http_request_method)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "ASP.NET Core Endpoint",
+  "uid": "NagEsjE4z",
+  "version": 2,
+  "weekStart": ""
+}

--- a/grafana/dashboards/aspnetcore.json
+++ b/grafana/dashboards/aspnetcore.json
@@ -1,0 +1,1357 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "ASP.NET Core metrics from OpenTelemetry",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 17706,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-green",
+            "mode": "continuous-GrYlRd",
+            "seriesBy": "max"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "index": 1,
+                  "text": "0 ms"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "p50"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.75, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p75",
+          "range": true,
+          "refId": "p75"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "p90"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.98, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p98",
+          "range": true,
+          "refId": "p98"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "p99"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.999, sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "p99.9",
+          "range": true,
+          "refId": "p99.9"
+        }
+      ],
+      "title": "Requests Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic",
+            "seriesBy": "max"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "index": 1,
+                  "text": "0%"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "All"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4XX"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5XX"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 47,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_response_status_code=~\"4..|5..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "legendFormat": "All",
+          "range": true,
+          "refId": "All"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_response_status_code=~\"4..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "4XX",
+          "range": true,
+          "refId": "4XX"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\", http_response_status_code=~\"5..\"}[$__rate_interval]) or vector(0)) / sum(rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "hide": false,
+          "legendFormat": "5XX",
+          "range": true,
+          "refId": "5XX"
+        }
+      ],
+      "title": "Errors Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 9
+      },
+      "id": 49,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(kestrel_active_connections{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "active connections",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Current Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 9
+      },
+      "id": 55,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(http_server_active_requests{job=~\"$job\", instance=~\"$instance\"})",
+          "legendFormat": "active requests",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Current Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 9
+      },
+      "id": 58,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value"
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__range])))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "dark-red",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 9
+      },
+      "id": 59,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "value"
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", error_type!=\"\"}[$__range])))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Unhandled Exceptions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 13
+      },
+      "id": 60,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (url_scheme) (\r\n    ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__range]))\r\n  )",
+          "legendFormat": "{{scheme}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests Secured",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "purple",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 13
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (method_route) (\r\n    label_replace(ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__range])), \"method_route\", \"http/$1\", \"network_protocol_version\", \"(.*)\")\r\n  )",
+          "legendFormat": "{{protocol}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests HTTP Protocol",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-BlPu"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Endpoint"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": false,
+                    "title": "${__data.fields.http_request_method} ${__data.fields.http_route}",
+                    "url": "/d/NagEsjE4z/asp-net-core-endpoint-details?${job:queryparam}&${instance:queryparam}&var-route=${__data.fields.http_route}&var-method=${__data.fields.http_request_method}&${__url_time_range}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_route"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_request_method"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "hideTimeOverride": false,
+      "id": 51,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "  topk(10,\r\n  sum by (http_route, http_request_method, method_route) (\r\n    label_join(ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route!=\"\"}[$__range])), \"method_route\", \" \", \"http_request_method\", \"http_route\")\r\n  ))",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{route}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Requested Endpoints",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "method": false,
+              "route": false
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 4,
+              "method": 2,
+              "method_route": 3,
+              "route": 1
+            },
+            "renameByName": {
+              "Value": "Requests",
+              "method": "",
+              "method_route": "Endpoint",
+              "route": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 300
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-YlRd"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Endpoint"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": false,
+                    "title": "${__data.fields.http_request_method} ${__data.fields.http_route}",
+                    "url": "/d/NagEsjE4z/asp-net-core-endpoint-details?${job:queryparam}&${instance:queryparam}&var-route=${__data.fields.http_route}&var-method=${__data.fields.http_request_method}&${__url_time_range}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_route"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "http_request_method"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "hideTimeOverride": false,
+      "id": 54,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "  topk(10,\r\n  sum by (http_route, http_request_method, method_route) (\r\n    label_join(ceil(increase(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_route!=\"\", error_type!=\"\"}[$__range])), \"method_route\", \" \", \"http_request_method\", \"http_route\")\r\n  ))",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{route}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 Unhandled Exception Endpoints",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "method": false
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 4,
+              "method": 2,
+              "method_route": 3,
+              "route": 1
+            },
+            "renameByName": {
+              "Value": "Requests",
+              "method": "",
+              "method_route": "Endpoint",
+              "route": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "10s",
+  "revision": 1,
+  "schemaVersion": 39,
+  "tags": [
+    "dotnet",
+    "prometheus",
+    "aspnetcore"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "label_values(http_server_active_requests,job)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_active_requests,job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "label_values(http_server_active_requests{job=~\"$job\"},instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(http_server_active_requests{job=~\"$job\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1s",
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "ASP.NET Core",
+  "uid": "KdDACDp4z",
+  "version": 2,
+  "weekStart": ""
+}

--- a/otelcollector/config.yaml
+++ b/otelcollector/config.yaml
@@ -1,0 +1,42 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  debug:
+    verbosity: detailed
+  otlp/aspire:
+    endpoint: ${env:ASPIRE_ENDPOINT}
+    headers:
+      x-otlp-api-key: ${env:ASPIRE_API_KEY}
+    tls:
+        insecure: ${env:ASPIRE_INSECURE}
+        insecure_skip_verify: true # Required in local development because cert is localhost and the endpoint is host.docker.internal
+  otlphttp/prometheus:
+    endpoint: ${env:PROMETHEUS_ENDPOINT}
+    tls:
+        insecure: true
+  
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/aspire]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/aspire]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters:
+        - otlp/aspire
+        - otlphttp/prometheus

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,5 @@
+storage:
+  tsdb:
+    out_of_order_time_window: 30m
+
+otlp:

--- a/src/aspire/SecureVault.AppHost/AppHost.cs
+++ b/src/aspire/SecureVault.AppHost/AppHost.cs
@@ -1,70 +1,91 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-var jwtKey = builder.Configuration["JwtSettings:Key"];
-var jwtRefreshKey = builder.Configuration["JwtSettings:RefreshTokenKey"];
-
-if (string.IsNullOrEmpty(jwtKey) || string.IsNullOrEmpty(jwtRefreshKey))
-{
-  throw new InvalidOperationException("JwtSettings 'secrets.json' dosyasında bulunamadı veya eksik.");
-}
+var jwtKeyParameter = builder.AddParameter("jwtkey", secret: true);
+var jwtRefreshKeyParameter = builder.AddParameter("jwtrefreshkey", secret: true);
 
 
-var seqPassword = builder.AddParameter("seqpassword", secret: true);
-var seq = builder.AddContainer("seq", "datalust/seq", "latest")
-                  .WithEnvironment("ACCEPT_EULA", "Y")
-                  .WithEnvironment("SEQ_FIRSTRUN_ADMINPASSWORD", seqPassword)
-                  .WithHttpEndpoint(port: 5341, targetPort: 80, name: "http");
+var seq = builder.AddSeq("seq");
 
 var postgresUsernameParameter = builder.AddParameter("postgresusername", secret: false);
 var postgresPasswordParameter = builder.AddParameter("postgrespassword", secret: true);
 var identityDb = builder.AddPostgres("identity-db")
                         .WithPassword(postgresPasswordParameter)
                         .WithUserName(postgresUsernameParameter)
+                        .WithArgs("-c", "max_connections=500")
                         .WithDataVolume();
 
-var redisCache = builder.AddRedis("redis-cache");
-var vaultDb = builder.AddMongoDB("vault-db")
-                     .WithDataVolume();
-
-var identityApi = builder.AddProject<Projects.SecureVault_Identity_Api>("identityapi");
-var vaultApi = builder.AddProject<Projects.SecureVault_Vault_Api>("vaultapi");
-var interactionApi = builder.AddProject<Projects.SecureVault_Interaction_Api>("interactionapi");
-var apigateway = builder.AddProject<Projects.SecureVault_ApiGateway>("apigateway").WithExternalHttpEndpoints();
+var vaultDb = builder.AddMongoDB("vault-db").WithDataVolume();
 
 
-var jwtIssuer = identityApi.GetEndpoint("https");
-var jwtAudience = apigateway.GetEndpoint("https");
+var redisPasswordParameter = builder.AddParameter("redispassword", secret: true);
+var redisCache = builder.AddRedis("redis-cache")
+                        .WithPassword(redisPasswordParameter);
+
+var prometheus = builder.AddContainer("prometheus", "prom/prometheus", "v3.2.1")
+                        .WithBindMount("../../../prometheus", "/etc/prometheus", isReadOnly: true)
+                        .WithArgs("--web.enable-otlp-receiver", "--config.file=/etc/prometheus/prometheus.yml")
+                        .WithHttpEndpoint(targetPort: 9090, name: "http");
+
+var grafana = builder.AddContainer("grafana", "grafana/grafana")
+                     .WithBindMount("../../../grafana/config", "/etc/grafana", isReadOnly: true)
+                     .WithBindMount("../../../grafana/dashboards", "/var/lib/grafana/dashboards", isReadOnly: true)
+                     .WithEnvironment("PROMETHEUS_ENDPOINT", prometheus.GetEndpoint("http"))
+                     .WithHttpEndpoint(targetPort: 3000, name: "http");
+
+builder.AddOpenTelemetryCollector("otelcollector")
+       .WithConfig("../../../otelcollector/config.yaml")
+       .WithAppForwarding()
+       .WithEnvironment("PROMETHEUS_ENDPOINT", $"{prometheus.GetEndpoint("http")}/api/v1/otlp");
+
+var identityApi = builder.AddProject<Projects.SecureVault_Identity_Api>("identity-api");
+var vaultApi = builder.AddProject<Projects.SecureVault_Vault_Api>("vault-api");
+var interactionApi = builder.AddProject<Projects.SecureVault_Interaction_Api>("interaction-api");
+var apigateway = builder.AddProject<Projects.SecureVault_ApiGateway>("api-gateway");
+
+var gatewayTunnel = builder.AddDevTunnel("public-gateway")
+                           .WithReference(apigateway)
+                           .WithAnonymousAccess();
+
+var jwtIssuer = "https://identity.securevault.local";
+var jwtAudience = apigateway.Resource.Name;
+
 
 identityApi.WithReference(identityDb)
            .WithReference(redisCache)
-           .WithEnvironment("JwtSettings__Key", jwtKey)
-           .WithEnvironment("JwtSettings__RefreshTokenKey", jwtRefreshKey)
+           .WithReference(seq)
+           .WithEnvironment("JwtSettings__Key", jwtKeyParameter)
+           .WithEnvironment("JwtSettings__RefreshTokenKey", jwtRefreshKeyParameter)
            .WithEnvironment("JwtSettings__Issuer", jwtIssuer)
            .WithEnvironment("JwtSettings__Audience", jwtAudience)
-           .WithEnvironment("Serilog__WriteTo__0__Args__serverUrl", seq.GetEndpoint("http"));
+           .WithEnvironment("GRAFANA_URL", grafana.GetEndpoint("http"))
+           .WithReplicas(3);
 
 vaultApi.WithReference(vaultDb)
-        .WithEnvironment("JwtSettings__Key", jwtKey)
+        .WithReference(seq)
+        .WithEnvironment("JwtSettings__Key", jwtKeyParameter)
         .WithEnvironment("JwtSettings__Issuer", jwtIssuer)
         .WithEnvironment("JwtSettings__Audience", jwtAudience)
-        .WithEnvironment("Serilog__WriteTo__0__Args__serverUrl", seq.GetEndpoint("http"))
-        .WithEnvironment("MongoDbSettings__DatabaseName", "securevault_db");
+        .WithEnvironment("MongoDbSettings__DatabaseName", "securevault_db")
+        .WithEnvironment("GRAFANA_URL", grafana.GetEndpoint("http"));
 
 interactionApi.WithReference(redisCache)
-              .WithEnvironment("JwtSettings__Key", jwtKey)
+              .WithReference(seq)
+              .WithEnvironment("JwtSettings__Key", jwtKeyParameter)
               .WithEnvironment("JwtSettings__Issuer", jwtIssuer)
               .WithEnvironment("JwtSettings__Audience", jwtAudience)
-              .WithEnvironment("Serilog__WriteTo__0__Args__serverUrl", seq.GetEndpoint("http"))
-              .WithEnvironment("CorsSettings__AllowedOrigin", apigateway.GetEndpoint("https"));
-
+              .WithEnvironment("CorsSettings__AllowedOrigin", jwtAudience)
+              .WithEnvironment("GRAFANA_URL", grafana.GetEndpoint("http"));
 
 apigateway.WithReference(redisCache)
+          .WithReference(seq)
           .WithReference(identityApi)
           .WithReference(vaultApi)
           .WithReference(interactionApi)
-          .WithEnvironment("JwtSettings__Key", jwtKey)
+          .WithEnvironment("JwtSettings__Key", jwtKeyParameter)
           .WithEnvironment("JwtSettings__Issuer", jwtIssuer)
           .WithEnvironment("JwtSettings__Audience", jwtAudience)
-          .WithEnvironment("Serilog__WriteTo__0__Args__serverUrl", seq.GetEndpoint("http"));
+          .WithEnvironment("GRAFANA_URL", grafana.GetEndpoint("http"));
+
+builder.AddKubernetesEnvironment("k8s");
 
 builder.Build().Run();

--- a/src/aspire/SecureVault.AppHost/SecureVault.AppHost.csproj
+++ b/src/aspire/SecureVault.AppHost/SecureVault.AppHost.csproj
@@ -11,10 +11,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.5.2" />
+    <PackageReference Include="Aspire.Hosting.DevTunnels" Version="9.5.2-preview.1.25522.3" />
+    <PackageReference Include="Aspire.Hosting.Kubernetes" Version="9.5.2-preview.1.25522.3" />
     <PackageReference Include="Aspire.Hosting.MongoDB" Version="9.5.2" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.5.2" />
     <PackageReference Include="Aspire.Hosting.Redis" Version="9.5.2" />
+    <PackageReference Include="Aspire.Hosting.Seq" Version="9.5.2" />
+    <PackageReference Include="CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector" Version="9.9.0" />
+
   </ItemGroup>
 
     <ItemGroup>

--- a/src/clients/SecureVault.App.Application/Services/AesGcmCryptoService.cs
+++ b/src/clients/SecureVault.App.Application/Services/AesGcmCryptoService.cs
@@ -16,7 +16,7 @@ namespace SecureVault.App.Application.Services
         {
             var plaintextBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(dataToEncrypt));
 
-            using var aesGcm = new AesGcm(encryptionKey);
+            using var aesGcm = new AesGcm(encryptionKey, TagSize);
 
             var nonce = new byte[NonceSize];
             var tag = new byte[TagSize];
@@ -42,7 +42,7 @@ namespace SecureVault.App.Application.Services
             var tag = new ReadOnlySpan<byte>(encryptedData, NonceSize, TagSize);
             var ciphertext = new ReadOnlySpan<byte>(encryptedData, NonceSize + TagSize, encryptedData.Length - (NonceSize + TagSize));
 
-            using var aesGcm = new AesGcm(encryptionKey);
+            using var aesGcm = new AesGcm(encryptionKey, TagSize);
 
             var plaintextBytes = new byte[ciphertext.Length];
 
@@ -56,7 +56,7 @@ namespace SecureVault.App.Application.Services
             }
 
             var jsonString = Encoding.UTF8.GetString(plaintextBytes);
-            return JsonSerializer.Deserialize<T>(jsonString);
+            return JsonSerializer.Deserialize<T>(jsonString)!;
         }
 
 
@@ -65,7 +65,7 @@ namespace SecureVault.App.Application.Services
             if (encryptionKey.Length != AesKeySize)
                 throw new ArgumentException($"Invalid key size. Key must be {AesKeySize} bytes.", nameof(encryptionKey));
 
-            using var aesGcm = new AesGcm(encryptionKey);
+            using var aesGcm = new AesGcm(encryptionKey, TagSize);
             var nonce = new byte[NonceSize];
             var tag = new byte[TagSize];
             var ciphertext = new byte[plaintextBytes.Length];
@@ -92,7 +92,7 @@ namespace SecureVault.App.Application.Services
             var tag = new ReadOnlySpan<byte>(encryptedData, NonceSize, TagSize);
             var ciphertext = new ReadOnlySpan<byte>(encryptedData, NonceSize + TagSize, encryptedData.Length - (NonceSize + TagSize));
 
-            using var aesGcm = new AesGcm(encryptionKey);
+            using var aesGcm = new AesGcm(encryptionKey, TagSize);
             var plaintextBytes = new byte[ciphertext.Length];
 
             try

--- a/src/clients/SecureVault.App/appsettings.json
+++ b/src/clients/SecureVault.App/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ApiSettings": {
-    "BaseUrl": "https://use-your-local-ip-with-gateway-port-or-use-forwarded-ports/"
+    "BaseUrl": "https://replace-this-with-your-api-gateway-devtunnel/"
   },
   "SignalRSettings": {
     "HubPath": "/interaction/hubs/interaction-hub"

--- a/src/gateways/SecureVault.ApiGateway/Program.cs
+++ b/src/gateways/SecureVault.ApiGateway/Program.cs
@@ -1,8 +1,12 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.IdentityModel.Tokens;
+using OpenTelemetry.Metrics;
 using SecureVault.ApiGateway.Helpers;
 using SecureVault.ApiGateway.MiddleWares;
 using Serilog;
+using Serilog.Enrichers.OpenTelemetry;
+using Serilog.Events;
 using System.Text;
 
 namespace SecureVault.ApiGateway
@@ -16,16 +20,29 @@ namespace SecureVault.ApiGateway
             builder.AddServiceDefaults();
 
             builder.Host.UseSerilog((context, services, configuration) => configuration
-                .ReadFrom.Configuration(context.Configuration)
                 .ReadFrom.Services(services)
+                .MinimumLevel.Information()
                 .Enrich.FromLogContext()
                 .Enrich.WithProperty("ApplicationName", "SecureVault.ApiGateway")
-                .Enrich.WithActivityId()
-                .Enrich.WithActivityTags());
+                .Enrich.WithOpenTelemetrySpanId()
+                .Enrich.WithOpenTelemetryTraceId()
+                .WriteTo.Console()
+                .WriteTo.Seq(
+                    builder.Configuration.GetConnectionString("seq"),
+                    restrictedToMinimumLevel: LogEventLevel.Information));
 
             Log.Information("Uygulama başlatılıyor.");
 
             builder.Services.AddServiceDiscovery();
+
+            builder.Services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+                options.KnownProxies.Clear();
+                options.KnownNetworks.Clear();
+            });
+
+            builder.AddSeqEndpoint("seq");
 
             builder.AddRedisClient("redis-cache");
 
@@ -59,32 +76,17 @@ namespace SecureVault.ApiGateway
                             .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"))
                             .AddServiceDiscoveryDestinationResolver();
 
-            var origins = builder.Configuration.GetSection("Cors:Origins").Get<string[]>();
-
-
-            builder.Services.AddCors(options =>
-            {
-                options.AddPolicy("SecureVaultApp",
-                    policyBuilder =>
-                    {
-                        policyBuilder.WithOrigins(origins ?? [])
-                                     .AllowAnyMethod()
-                                     .AllowAnyHeader()
-                                     .AllowCredentials()
-                                     .SetPreflightMaxAge(TimeSpan.FromMinutes(10));
-                    });
-            });
-
             var app = builder.Build();
 
             app.UseSerilogRequestLogging();
+            app.UseForwardedHeaders();
             app.UseHttpsRedirection();
-            app.UseCors("SecureVaultApp");
             app.UseRouting();
             app.UseAuthentication();
             app.UseMiddleware<TokenBlacklistMiddleware>();
             app.UseAuthorization();
             app.UseWebSockets();
+            app.MapDefaultEndpoints();
             app.MapReverseProxy();
 
             app.Run();

--- a/src/gateways/SecureVault.ApiGateway/Properties/launchSettings.json
+++ b/src/gateways/SecureVault.ApiGateway/Properties/launchSettings.json
@@ -14,7 +14,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "dotnetRunMessages": true,
-      "applicationUrl": "https://*:7202"
+      "applicationUrl": "https://localhost:7202"
     }
   },
   "$schema": "https://json.schemastore.org/launchsettings.json"

--- a/src/gateways/SecureVault.ApiGateway/SecureVault.ApiGateway.csproj
+++ b/src/gateways/SecureVault.ApiGateway/SecureVault.ApiGateway.csproj
@@ -6,18 +6,18 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 		<DockerfileContext>..\..\..</DockerfileContext>
-		<DockerComposeProjectPath>..\..\..\docker-compose.dcproj</DockerComposeProjectPath>
 		<UserSecretsId>f6a38ce6-ac7c-4f86-bfbf-41791b007e71</UserSecretsId>
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Aspire.Seq" Version="9.5.2" />
 		<PackageReference Include="Aspire.StackExchange.Redis" Version="9.5.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.9" />
 		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="9.5.2" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
 		<PackageReference Include="Serilog" Version="4.3.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-		<PackageReference Include="Serilog.Enrichers.Activity" Version="1.0.0.3" />
+		<PackageReference Include="Serilog.Enrichers.OpenTelemetry" Version="1.0.1" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/gateways/SecureVault.ApiGateway/appsettings.json
+++ b/src/gateways/SecureVault.ApiGateway/appsettings.json
@@ -1,12 +1,4 @@
 {
-  "Cors": {
-    "Origins": [
-      "http://localhost:5234",
-      "https://0.0.0.0",
-      "https://0.0.0.1",
-      "https://localhost:7202/"
-    ]
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",
@@ -14,36 +6,5 @@
     }
   },
   "AllowedHosts": "*",
-  "ApplicationName": "ApiGateway",
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console",
-      "Serilog.Sinks.Seq"
-    ],
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information",
-        "System": "Warning"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "Console"
-      },
-      {
-        "Name": "Seq",
-        "Args": {
-          "serverUrl": "http://localhost:5341"
-        }
-      }
-    ],
-    "Enrich": [
-      "FromLogContext"
-    ]
-  },
-  "ForwardedHeadersOptions": {
-    "KnownNetworks": "172.22.0.0/16"
-  }
+  "ApplicationName": "ApiGateway"
 }

--- a/src/gateways/SecureVault.ApiGateway/yarp.json
+++ b/src/gateways/SecureVault.ApiGateway/yarp.json
@@ -1,24 +1,6 @@
 {
   "ReverseProxy": {
     "Routes": {
-      "interaction-route": {
-        "ClusterId": "interaction-cluster",
-        "Match": {
-          "Path": "/interaction/{**everything}",
-          "Methods": [
-            "GET",
-            "POST",
-            "PUT",
-            "DELETE"
-          ]
-        },
-        "Transforms": [
-          {
-            "PathRemovePrefix": "/interaction"
-          }
-        ],
-        "Order": 2
-      },
       "identity-route": {
         "ClusterId": "identity-cluster",
         "Match": {
@@ -31,10 +13,6 @@
           ]
         },
         "Transforms": [
-          {
-            "RequestHeader": "X-Forwarded-For",
-            "Set": "{RemoteIpAddress}"
-          },
           {
             "PathRemovePrefix": "/identity"
           }
@@ -59,30 +37,48 @@
         ],
         "AuthorizationPolicy": "default",
         "Order": 2
+      },
+      "interaction-route": {
+        "ClusterId": "interaction-cluster",
+        "Match": {
+          "Path": "/interaction/{**everything}",
+          "Methods": [
+            "GET",
+            "POST",
+            "PUT",
+            "DELETE"
+          ]
+        },
+        "Transforms": [
+          {
+            "PathRemovePrefix": "/interaction"
+          }
+        ],
+        "Order": 2
       }
     },
     "Clusters": {
       "identity-cluster": {
-        "LoadBalancingPolicy": "LeastRequests",
+        "LoadBalancingPolicy": "PowerOfTwoChoices",
         "Destinations": {
           "destination1": {
-            "Address": "http://identityapi"
+            "Address": "http://identity-api"
           }
         }
       },
       "vault-cluster": {
-        "LoadBalancingPolicy": "LeastRequests",
+        "LoadBalancingPolicy": "PowerOfTwoChoices",
         "Destinations": {
           "destination1": {
-            "Address": "http://vaultapi"
+            "Address": "http://vault-api"
           }
         }
       },
       "interaction-cluster": {
-        "LoadBalancingPolicy": "LeastRequests",
+        "LoadBalancingPolicy": "PowerOfTwoChoices",
         "Destinations": {
           "destination1": {
-            "Address": "http://interactionapi"
+            "Address": "http://interaction-api"
           }
         }
       }

--- a/src/services/Identity/SecureVault.Identity.Api/Controllers/AuthController.cs
+++ b/src/services/Identity/SecureVault.Identity.Api/Controllers/AuthController.cs
@@ -39,10 +39,6 @@ namespace SecureVault.Identity.Api.Controllers
             var deviceModel = Request.Headers["X-Device-Model"].FirstOrDefault();
             var deviceManufacturer = Request.Headers["X-Device-Manufacturer"].FirstOrDefault();
             var operatingSystem = Request.Headers["X-Device-OS"].FirstOrDefault();
-            var dpopProof = Request.Headers["DPoP"].FirstOrDefault();
-            var uri = new Uri(Request.GetDisplayUrl());
-            var requestUrl = uri.AbsolutePath;
-            var requestMethod = Request.Method;
             var command = new LoginUserCommand(
                 credentials.Email,
                 credentials.Signature,
@@ -52,10 +48,7 @@ namespace SecureVault.Identity.Api.Controllers
                 deviceModel,
                 deviceManufacturer,
                 operatingSystem,
-                ipAddress,
-                dpopProof,
-                requestUrl,
-                requestMethod
+                ipAddress
             );
 
             var result = await _mediator.Send(command);
@@ -69,19 +62,12 @@ namespace SecureVault.Identity.Api.Controllers
         [HttpPost("refresh")]
         public async Task<IActionResult> RefreshToken()
         {
-            var uri = new Uri(Request.GetDisplayUrl());
-            var requestUrl = uri.AbsolutePath;
-            var requestMethod = Request.Method;
-
             var command = new RefreshTokenCommand(
                 Request.Headers.Authorization.FirstOrDefault()?.Split(" ").Last(),
                 Request.Headers["X-Refresh-Token"].FirstOrDefault(),
                 HttpContext.Connection.RemoteIpAddress?.ToString(),
                 Request.Headers["X-Device-Id"].FirstOrDefault(),
-                Request.Headers["X-Device-Name"].FirstOrDefault(),
-                Request.Headers["DPoP"].FirstOrDefault(),
-                requestUrl,
-                requestMethod
+                Request.Headers["X-Device-Name"].FirstOrDefault()
             );
             var result = await _mediator.Send(command);
             return result.IsSuccess ? Ok(result.Value) : BadRequest(result.Error);

--- a/src/services/Identity/SecureVault.Identity.Api/Program.cs
+++ b/src/services/Identity/SecureVault.Identity.Api/Program.cs
@@ -5,9 +5,9 @@ using SecureVault.Identity.Api.Extensions;
 using SecureVault.Identity.Application;
 using SecureVault.Identity.Infrastructure.Helpers;
 using Serilog;
-using System.Net;
+using Serilog.Enrichers.OpenTelemetry;
+using Serilog.Events;
 using System.Text;
-using IPNetwork = Microsoft.AspNetCore.HttpOverrides.IPNetwork;
 
 namespace SecureVault.Identity.Api
 {
@@ -20,12 +20,16 @@ namespace SecureVault.Identity.Api
             builder.AddServiceDefaults();
 
             builder.Host.UseSerilog((context, services, configuration) => configuration
-                .ReadFrom.Configuration(context.Configuration)
                 .ReadFrom.Services(services)
+                .MinimumLevel.Information()
                 .Enrich.FromLogContext()
                 .Enrich.WithProperty("ApplicationName", "SecureVault.Identity.Api")
-                .Enrich.WithActivityId()
-                .Enrich.WithActivityTags());
+                .Enrich.WithOpenTelemetrySpanId()
+                .Enrich.WithOpenTelemetryTraceId()
+                .WriteTo.Console()
+                .WriteTo.Seq(
+                    builder.Configuration.GetConnectionString("seq"),
+                    restrictedToMinimumLevel: LogEventLevel.Information));
 
             Log.Information("Uygulama başlatılıyor.");
 
@@ -38,20 +42,11 @@ namespace SecureVault.Identity.Api
 
             builder.Services.Configure<ForwardedHeadersOptions>(options =>
             {
-                options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost;
-                options.KnownNetworks.Clear();
+                options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
                 options.KnownProxies.Clear();
-
-
-                var knownNetworks = builder.Configuration["ForwardedHeadersOptions:KnownNetworks"];
-                if (!string.IsNullOrEmpty(knownNetworks))
-                {
-                    var cidrParts = knownNetworks.Split('/');
-                    if (cidrParts.Length == 2 && IPAddress.TryParse(cidrParts[0], out var ipAddress) && int.TryParse(cidrParts[1], out var prefixLength))
-                        options.KnownNetworks.Add(new IPNetwork(ipAddress, prefixLength));
-                }
-                //options.KnownNetworks.Add(new IPNetwork(IPAddress.Parse("::ffff:172.22.0.0"), 112));
+                options.KnownNetworks.Clear();
             });
+            builder.AddSeqEndpoint("seq");
 
             builder.AddRedisClient("redis-cache");
 

--- a/src/services/Identity/SecureVault.Identity.Api/SecureVault.Identity.Api.csproj
+++ b/src/services/Identity/SecureVault.Identity.Api/SecureVault.Identity.Api.csproj
@@ -11,6 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Aspire.Seq" Version="9.5.2" />
 		<PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.5.2" />
 		<PackageReference Include="Aspire.StackExchange.Redis" Version="9.5.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.9" />
@@ -22,7 +23,7 @@
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
 		<PackageReference Include="Serilog" Version="4.3.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-		<PackageReference Include="Serilog.Enrichers.Activity" Version="1.0.0.3" />
+		<PackageReference Include="Serilog.Enrichers.OpenTelemetry" Version="1.0.1" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/services/Identity/SecureVault.Identity.Api/appsettings.json
+++ b/src/services/Identity/SecureVault.Identity.Api/appsettings.json
@@ -6,36 +6,5 @@
     }
   },
   "AllowedHosts": "*",
-  "ApplicationName": "Identity.Api",
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console",
-      "Serilog.Sinks.Seq"
-    ],
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information",
-        "System": "Warning"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "Console"
-      },
-      {
-        "Name": "Seq",
-        "Args": {
-          "serverUrl": "http://localhost:5341"
-        }
-      }
-    ],
-    "Enrich": [
-      "FromLogContext"
-    ]
-  },
-  "ForwardedHeadersOptions": {
-    "KnownNetworks": "172.22.0.0/16"
-  }
+  "ApplicationName": "Identity.Api"
 }

--- a/src/services/Identity/SecureVault.Identity.Application/Features/CQRS/Auth/Commands/LoginUserCommand.cs
+++ b/src/services/Identity/SecureVault.Identity.Application/Features/CQRS/Auth/Commands/LoginUserCommand.cs
@@ -13,10 +13,5 @@ namespace SecureVault.Identity.Application.Features.CQRS.Auth.Commands
         string? DeviceModel,
         string? DeviceManufacturer,
         string? OperatingSystem,
-        string? IpAddress,
-        string? dpopProof,
-        string requestUrl,
-        string requestMethod
-        )
-        : IRequest<Result<AuthResponse>>;
+        string? IpAddress) : IRequest<Result<AuthResponse>>;
 }

--- a/src/services/Identity/SecureVault.Identity.Application/Features/CQRS/Auth/Commands/RefreshTokenCommand.cs
+++ b/src/services/Identity/SecureVault.Identity.Application/Features/CQRS/Auth/Commands/RefreshTokenCommand.cs
@@ -10,9 +10,6 @@ namespace SecureVault.Identity.Application.Features.CQRS.Auth.Commands
 
         string? IpAddress,
         string? UniqueDeviceId,
-        string? DeviceName,
-        string dpopProof,
-        string requestUrl,
-        string requestMethod
+        string? DeviceName
     ) : IRequest<Result<AuthResponse>>;
 }

--- a/src/services/Identity/SecureVault.Identity.Application/Features/CQRS/Register/Handlers/RegisterUserHandler.cs
+++ b/src/services/Identity/SecureVault.Identity.Application/Features/CQRS/Register/Handlers/RegisterUserHandler.cs
@@ -41,7 +41,7 @@ namespace SecureVault.Identity.Application.Features.CQRS.Register.Handlers
                 await _userRepository.AddAsync(newUser);
                 await _userRecoveryDataRepository.CreateAsync(newRecoveryData);
 
-                await _unitOfWork.SaveChangesWithTransactionAsync();
+                await _unitOfWork.SaveChangesAsync();
 
                 return Result.Success();
             }

--- a/src/services/Interaction/SecureVault.Interaction.Api/Program.cs
+++ b/src/services/Interaction/SecureVault.Interaction.Api/Program.cs
@@ -5,6 +5,8 @@ using SecureVault.Interaction.Api.Features.Interaction;
 using SecureVault.Interaction.Api.Features.QrLogin;
 using SecureVault.Interaction.Api.Helpers;
 using Serilog;
+using Serilog.Enrichers.OpenTelemetry;
+using Serilog.Events;
 using StackExchange.Redis;
 using System.Text;
 
@@ -19,12 +21,16 @@ namespace SecureVault.Interaction.Api
             builder.AddServiceDefaults();
 
             builder.Host.UseSerilog((context, services, configuration) => configuration
-                            .ReadFrom.Configuration(context.Configuration)
                             .ReadFrom.Services(services)
+                            .MinimumLevel.Information()
                             .Enrich.FromLogContext()
                             .Enrich.WithProperty("ApplicationName", "SecureVault.Interaction.Api")
-                            .Enrich.WithActivityId()
-                            .Enrich.WithActivityTags());
+                            .Enrich.WithOpenTelemetrySpanId()
+                            .Enrich.WithOpenTelemetryTraceId()
+                            .WriteTo.Console()
+                            .WriteTo.Seq(
+                                builder.Configuration.GetConnectionString("seq"),
+                                restrictedToMinimumLevel: LogEventLevel.Information));
 
             Log.Information("Uygulama başlatılıyor.");
 
@@ -33,6 +39,7 @@ namespace SecureVault.Interaction.Api
             builder.Services.AddOpenApi();
             builder.Services.AddLocalization();
 
+            builder.AddSeqEndpoint("seq");
 
             builder.AddRedisClient("redis-cache");
 

--- a/src/services/Interaction/SecureVault.Interaction.Api/SecureVault.Interaction.Api.csproj
+++ b/src/services/Interaction/SecureVault.Interaction.Api/SecureVault.Interaction.Api.csproj
@@ -10,6 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Aspire.Seq" Version="9.5.2" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.9" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="9.0.10" />
@@ -17,7 +18,7 @@
 		<PackageReference Include="Polly" Version="8.6.3" />
 		<PackageReference Include="Serilog" Version="4.3.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-		<PackageReference Include="Serilog.Enrichers.Activity" Version="1.0.0.3" />
+		<PackageReference Include="Serilog.Enrichers.OpenTelemetry" Version="1.0.1" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/services/Interaction/SecureVault.Interaction.Api/appsettings.json
+++ b/src/services/Interaction/SecureVault.Interaction.Api/appsettings.json
@@ -6,33 +6,5 @@
     }
   },
   "AllowedHosts": "*",
-  "ApplicationName": "Interaction.Api",
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console",
-      "Serilog.Sinks.Seq"
-    ],
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information",
-        "System": "Warning"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "Console"
-      },
-      {
-        "Name": "Seq",
-        "Args": {
-          "serverUrl": "http://localhost:5341"
-        }
-      }
-    ],
-    "Enrich": [
-      "FromLogContext"
-    ]
-  }
+  "ApplicationName": "Interaction.Api"
 }

--- a/src/services/Vault/SecureVault.Vault.Api/Program.cs
+++ b/src/services/Vault/SecureVault.Vault.Api/Program.cs
@@ -4,6 +4,8 @@ using SecureVault.Vault.Api.Extensions;
 using SecureVault.Vault.Api.Helpers;
 using SecureVault.Vault.Application;
 using Serilog;
+using Serilog.Enrichers.OpenTelemetry;
+using Serilog.Events;
 using System.Text;
 
 namespace SecureVault.Vault.Api
@@ -17,12 +19,16 @@ namespace SecureVault.Vault.Api
             builder.AddServiceDefaults();
 
             builder.Host.UseSerilog((context, services, configuration) => configuration
-                            .ReadFrom.Configuration(context.Configuration)
                             .ReadFrom.Services(services)
+                            .MinimumLevel.Information()
                             .Enrich.FromLogContext()
                             .Enrich.WithProperty("ApplicationName", "SecureVault.Vault.Api")
-                            .Enrich.WithActivityId()
-                            .Enrich.WithActivityTags());
+                            .Enrich.WithOpenTelemetrySpanId()
+                            .Enrich.WithOpenTelemetryTraceId()
+                            .WriteTo.Console()
+                            .WriteTo.Seq(
+                                builder.Configuration.GetConnectionString("seq"),
+                                restrictedToMinimumLevel: LogEventLevel.Information));
 
             Log.Information("Uygulama başlatılıyor.");
 
@@ -31,6 +37,8 @@ namespace SecureVault.Vault.Api
             builder.Services.RegisterServices();
             builder.Services.AddOpenApi();
             builder.Services.AddLocalization();
+
+            builder.AddSeqEndpoint("seq");
 
             builder.Services.AddMongoDbConfiguration(builder);
 

--- a/src/services/Vault/SecureVault.Vault.Api/SecureVault.Vault.Api.csproj
+++ b/src/services/Vault/SecureVault.Vault.Api/SecureVault.Vault.Api.csproj
@@ -10,6 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+		<PackageReference Include="Aspire.Seq" Version="9.5.2" />
         <PackageReference Include="Aspire.MongoDB.Driver" Version="9.5.2" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.9" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
@@ -17,7 +18,7 @@
         <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
         <PackageReference Include="Serilog" Version="4.3.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
-        <PackageReference Include="Serilog.Enrichers.Activity" Version="1.0.0.3" />
+        <PackageReference Include="Serilog.Enrichers.OpenTelemetry" Version="1.0.1" />
         <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/services/Vault/SecureVault.Vault.Api/appsettings.json
+++ b/src/services/Vault/SecureVault.Vault.Api/appsettings.json
@@ -6,33 +6,5 @@
     }
   },
   "AllowedHosts": "*",
-  "ApplicationName": "Vault.Api",
-  "Serilog": {
-    "Using": [
-      "Serilog.Sinks.Console",
-      "Serilog.Sinks.Seq"
-    ],
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information",
-        "System": "Warning"
-      }
-    },
-    "WriteTo": [
-      {
-        "Name": "Console"
-      },
-      {
-        "Name": "Seq",
-        "Args": {
-          "serverUrl": "http://localhost:5341"
-        }
-      }
-    ],
-    "Enrich": [
-      "FromLogContext"
-    ]
-  }
+  "ApplicationName": "Vault.Api"
 }


### PR DESCRIPTION
## 📝 Summary
This PR is a major infrastructure overhaul to complete the **Three Pillars of Observability (Logging, Tracing, Metrics)** and accelerate the mobile development loop.

1.  **Metrics (New):** The missing third pillar, Metrics, has been integrated by manually adding **Prometheus** and **Grafana** containers to the `.AppHost` using `AddContainer`.
2.  **Tunneling (New):** **Aspire Dev Tunnel** (`AddDevTunnel`) has been integrated to simplify mobile (MAUI) device testing, instantly exposing the API Gateway to the public internet.
3.  **Logging/Tracing (Fix):** The **Serilog**, **OpenTelemetry**, and **Seq** integration has been reconfigured for correct correlation (trace IDs) and now uses the proper `Aspire.Hosting.Seq` library.
4.  **Networking (Fix):** The `ForwardedHeaders` configuration has been corrected, ensuring the real client IP is captured behind YARP.

## 🎯 Motivation
1.  **The Missing Pillar: Metrics:** Our project had logging and tracing but lacked metrics (HOW healthy the system is). We needed Prometheus/Grafana to monitor vital health indicators.
2.  **Mobile Dev Friction:** It was difficult for the mobile client (MAUI) to access `localhost`. `AddDevTunnel` solves this by providing an instant, readable public URL from the Aspire dashboard.
3.  **Broken Correlation:** Logging and tracing were not fully integrated. Serilog logs were not correctly picking up the `TraceId` and `SpanId` from OpenTelemetry.
4.  **Incorrect Client IP:** Due to improper `X-Forwarded-For` handling behind YARP, all logs were showing the API Gateway's IP instead of the real client's IP.

## ✨ Key Technical Changes
* **1. Metrics Infrastructure (Prometheus & Grafana):**
    * As official `AddPrometheus/AddGrafana` methods do not (yet) exist, the containers were added manually to `.AppHost` using `builder.AddContainer(...)`.
    * Microsoft's official `yml` config files (`prometheus.yml`, `grafana-dashboards.yml`, etc.) were attached using `WithBindMount`.
    * Grafana's `PROMETHEUS_ENDPOINT` environment variable is now dynamically set using Aspire's service discovery (`prometheus.GetEndpoint("http")`).
* **2. Developer Tunneling:**
    * Added `builder.AddDevTunnel("public-gateway")` to `.AppHost`, referencing the `apigateway` service.
    * This creates a secure, public URL for the API Gateway every time Aspire runs, eliminating `localhost` configuration pain for mobile (MAUI) testing.
* **3. Observability (Logging & Tracing) Fix:**
    * Replaced the manual `AddContainer("seq", ...)` definition in `.AppHost` with the `builder.AddSeq("seq")` extension (from `Aspire.Hosting.Seq`).
    * Reconfigured `Serilog` in all services to correctly enrich logs with OpenTelemetry `TraceId` and `SpanId`.
* **4. Networking (Forwarded Headers) Fix:**
    * Added `ForwardedHeadersOptions` configuration to all API services, ensuring the *real* client IP is now logged instead of YARP's.
* **5. Cleanup:**
    * Removed unused or obsolete sections of code discovered during this refactoring.